### PR TITLE
Add Windows and Android build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,17 +4,24 @@ Codex.app/
 # Dependencies
 node_modules/
 .pnpm-store/
+.android-build-tools/
+.codex-bin/
+.runtime-test/
 
 # Build outputs
 out/
 dist/
 cache/
 release/
+android-shell/.gradle/
+android-shell/app/build/
 
 # Upstream ASAR extracts and build-time copies (all generated)
 src/
 !gateway/src/
 !gateway/src/**
+!android-shell/app/src/
+!android-shell/app/src/**
 
 # Version check state (local only)
 scripts/.versions.json

--- a/android-shell/app/build.gradle
+++ b/android-shell/app/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id "com.android.application"
+}
+
+android {
+    namespace "dev.opencodex.android"
+    compileSdk 35
+
+    defaultConfig {
+        applicationId "dev.opencodex.android"
+        minSdk 23
+        targetSdk 35
+        versionCode 1
+        versionName "1.0.0"
+    }
+}

--- a/android-shell/app/src/main/AndroidManifest.xml
+++ b/android-shell/app/src/main/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <application
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:label="@string/app_name"
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config">
+        <activity
+            android:name=".MainActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android-shell/app/src/main/java/dev/opencodex/android/MainActivity.java
+++ b/android-shell/app/src/main/java/dev/opencodex/android/MainActivity.java
@@ -1,0 +1,303 @@
+package dev.opencodex.android;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.GradientDrawable;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.Gravity;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.Window;
+import android.view.inputmethod.InputMethodManager;
+import android.view.inputmethod.EditorInfo;
+import android.webkit.WebChromeClient;
+import android.webkit.WebResourceError;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+
+public class MainActivity extends Activity {
+    private static final String PREFS = "opencodex";
+    private static final String KEY_URL = "gateway_url";
+
+    private EditText urlInput;
+    private TextView statusText;
+    private WebView webView;
+    private ScrollView setupView;
+    private Button settingsButton;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        configureSystemBars();
+        buildLayout();
+        configureWebView();
+        watchNetworkChanges();
+
+        String savedUrl = prefs().getString(KEY_URL, "");
+        if (!savedUrl.isEmpty()) {
+            urlInput.setText(savedUrl);
+            loadGateway(savedUrl);
+        } else {
+            showSetup("输入电脑端局域网地址后连接。");
+        }
+    }
+
+    private SharedPreferences prefs() {
+        return getSharedPreferences(PREFS, MODE_PRIVATE);
+    }
+
+    private void configureSystemBars() {
+        Window window = getWindow();
+        window.setStatusBarColor(Color.WHITE);
+        window.setNavigationBarColor(Color.WHITE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+        }
+    }
+
+    private void buildLayout() {
+        FrameLayout root = new FrameLayout(this);
+        root.setBackgroundColor(Color.WHITE);
+
+        webView = new WebView(this);
+        webView.setVisibility(View.GONE);
+        root.addView(webView, new FrameLayout.LayoutParams(-1, -1));
+
+        setupView = new ScrollView(this);
+        setupView.setFillViewport(true);
+        setupView.setBackgroundColor(Color.WHITE);
+
+        LinearLayout panel = new LinearLayout(this);
+        panel.setOrientation(LinearLayout.VERTICAL);
+        panel.setGravity(Gravity.CENTER_HORIZONTAL);
+        panel.setPadding(dp(22), dp(48), dp(22), dp(24));
+        setupView.addView(panel, new ScrollView.LayoutParams(-1, -1));
+
+        TextView title = new TextView(this);
+        title.setText("OpenCodex");
+        title.setTextColor(Color.rgb(17, 24, 39));
+        title.setTextSize(32);
+        title.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
+        panel.addView(title, new LinearLayout.LayoutParams(-1, -2));
+
+        TextView subtitle = new TextView(this);
+        subtitle.setText("连接电脑端服务，在手机上继续当前会话");
+        subtitle.setTextColor(Color.rgb(82, 91, 107));
+        subtitle.setTextSize(16);
+        subtitle.setPadding(0, dp(8), 0, dp(24));
+        subtitle.setLineSpacing(0, 1.18f);
+        panel.addView(subtitle, new LinearLayout.LayoutParams(-1, -2));
+
+        LinearLayout card = new LinearLayout(this);
+        card.setOrientation(LinearLayout.VERTICAL);
+        card.setPadding(dp(16), dp(18), dp(16), dp(16));
+        card.setBackground(rounded(Color.rgb(247, 249, 252), dp(18), Color.rgb(224, 229, 238), 1));
+        panel.addView(card, new LinearLayout.LayoutParams(-1, -2));
+
+        TextView label = new TextView(this);
+        label.setText("访问地址");
+        label.setTextColor(Color.rgb(40, 45, 53));
+        label.setTextSize(14);
+        label.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
+        card.addView(label, new LinearLayout.LayoutParams(-1, -2));
+
+        urlInput = new EditText(this);
+        urlInput.setSingleLine(true);
+        urlInput.setHint("例如 192.168.123.104:20095");
+        urlInput.setTextSize(16);
+        urlInput.setTextColor(Color.rgb(17, 24, 39));
+        urlInput.setHintTextColor(Color.rgb(145, 153, 166));
+        urlInput.setSelectAllOnFocus(true);
+        urlInput.setInputType(EditorInfo.TYPE_TEXT_VARIATION_URI);
+        urlInput.setImeOptions(EditorInfo.IME_ACTION_GO);
+        urlInput.setPadding(dp(12), 0, dp(12), 0);
+        urlInput.setBackground(rounded(Color.WHITE, dp(12), Color.rgb(213, 218, 226), 1));
+        LinearLayout.LayoutParams inputParams = new LinearLayout.LayoutParams(-1, dp(52));
+        inputParams.setMargins(0, dp(10), 0, dp(12));
+        card.addView(urlInput, inputParams);
+
+        Button connect = new Button(this);
+        connect.setText("连接");
+        connect.setTextColor(Color.WHITE);
+        connect.setTextSize(16);
+        connect.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
+        connect.setAllCaps(false);
+        connect.setBackground(rounded(Color.rgb(16, 139, 105), dp(14), Color.TRANSPARENT, 0));
+        card.addView(connect, new LinearLayout.LayoutParams(-1, dp(52)));
+
+        statusText = new TextView(this);
+        statusText.setTextColor(Color.rgb(112, 119, 130));
+        statusText.setTextSize(13);
+        statusText.setLineSpacing(0, 1.15f);
+        LinearLayout.LayoutParams statusParams = new LinearLayout.LayoutParams(-1, -2);
+        statusParams.setMargins(0, dp(14), 0, 0);
+        card.addView(statusText, statusParams);
+
+        TextView hint = new TextView(this);
+        hint.setText("电脑端需打开“局域网”访问；连接成功后只保留沉浸式手机界面。");
+        hint.setTextColor(Color.rgb(132, 139, 150));
+        hint.setTextSize(13);
+        hint.setLineSpacing(0, 1.2f);
+        LinearLayout.LayoutParams hintParams = new LinearLayout.LayoutParams(-1, -2);
+        hintParams.setMargins(0, dp(22), 0, 0);
+        panel.addView(hint, hintParams);
+
+        root.addView(setupView, new FrameLayout.LayoutParams(-1, -1));
+
+        settingsButton = new Button(this);
+        settingsButton.setText("地址");
+        settingsButton.setTextSize(13);
+        settingsButton.setAllCaps(false);
+        settingsButton.setTextColor(Color.rgb(40, 45, 53));
+        settingsButton.setBackground(rounded(Color.argb(235, 255, 255, 255), dp(18), Color.rgb(225, 229, 235), 1));
+        settingsButton.setVisibility(View.GONE);
+        FrameLayout.LayoutParams settingsParams = new FrameLayout.LayoutParams(dp(64), dp(38), Gravity.TOP | Gravity.CENTER_HORIZONTAL);
+        settingsParams.setMargins(0, dp(12), 0, 0);
+        root.addView(settingsButton, settingsParams);
+        settingsButton.setTranslationX(-dp(76));
+
+        setContentView(root);
+
+        connect.setOnClickListener(v -> connectFromInput());
+        settingsButton.setOnClickListener(v -> showSetup("修改地址后重新连接。"));
+        urlInput.setOnEditorActionListener((TextView v, int actionId, KeyEvent event) -> {
+            if (actionId == EditorInfo.IME_ACTION_GO) {
+                connectFromInput();
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private void configureWebView() {
+        WebSettings settings = webView.getSettings();
+        settings.setJavaScriptEnabled(true);
+        settings.setDomStorageEnabled(true);
+        settings.setDatabaseEnabled(true);
+        settings.setMediaPlaybackRequiresUserGesture(false);
+        settings.setLoadWithOverviewMode(false);
+        settings.setUseWideViewPort(true);
+        settings.setTextZoom(100);
+        settings.setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
+        settings.setUserAgentString(settings.getUserAgentString() + " OpenCodexAndroid/1.0");
+
+        webView.setBackgroundColor(Color.WHITE);
+        webView.setOverScrollMode(View.OVER_SCROLL_NEVER);
+        webView.setVerticalScrollBarEnabled(false);
+        webView.setHorizontalScrollBarEnabled(false);
+        WebView.setWebContentsDebuggingEnabled(false);
+        webView.setWebChromeClient(new WebChromeClient());
+        webView.setWebViewClient(new WebViewClient() {
+            @Override
+            public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+                return false;
+            }
+
+            @Override
+            public void onPageFinished(WebView view, String url) {
+                setupView.setVisibility(View.GONE);
+                webView.setVisibility(View.VISIBLE);
+                settingsButton.setVisibility(View.VISIBLE);
+            }
+
+            @Override
+            public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
+                if (request != null && request.isForMainFrame()) {
+                    showSetup("连接失败，请确认电脑和手机在同一网络，且电脑端已切到局域网模式。");
+                }
+            }
+        });
+    }
+
+    private void connectFromInput() {
+        String value = normalizeUrl(urlInput.getText().toString());
+        if (value.isEmpty()) return;
+        urlInput.setText(value);
+        hideKeyboard();
+        prefs().edit().putString(KEY_URL, value).apply();
+        loadGateway(value);
+    }
+
+    private void loadGateway(String url) {
+        statusText.setText("正在连接 " + url);
+        webView.setVisibility(View.VISIBLE);
+        webView.loadUrl(url);
+    }
+
+    private void showSetup(String message) {
+        webView.setVisibility(View.GONE);
+        statusText.setText(message);
+        setupView.setVisibility(View.VISIBLE);
+        settingsButton.setVisibility(View.GONE);
+    }
+
+    private void hideKeyboard() {
+        urlInput.clearFocus();
+        InputMethodManager manager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+        if (manager != null) {
+            manager.hideSoftInputFromWindow(urlInput.getWindowToken(), 0);
+        }
+    }
+
+    private String normalizeUrl(String raw) {
+        String value = raw == null ? "" : raw.trim();
+        if (value.isEmpty()) return "";
+        if (!value.startsWith("http://") && !value.startsWith("https://")) {
+            value = "http://" + value;
+        }
+        return value;
+    }
+
+    private void watchNetworkChanges() {
+        ConnectivityManager manager = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (manager == null) return;
+        manager.registerDefaultNetworkCallback(new ConnectivityManager.NetworkCallback() {
+            @Override
+            public void onAvailable(Network network) {
+                runOnUiThread(() -> {
+                    String url = prefs().getString(KEY_URL, "");
+                    if (!url.isEmpty() && webView.getUrl() == null) loadGateway(url);
+                });
+            }
+        });
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (setupView.getVisibility() != View.VISIBLE && webView.canGoBack()) {
+            webView.goBack();
+        } else if (setupView.getVisibility() != View.VISIBLE) {
+            showSetup("修改地址后重新连接。");
+        } else {
+            super.onBackPressed();
+        }
+    }
+
+    private GradientDrawable rounded(int color, int radius, int strokeColor, int strokeWidth) {
+        GradientDrawable drawable = new GradientDrawable();
+        drawable.setColor(color);
+        drawable.setCornerRadius(radius);
+        if (strokeWidth > 0) drawable.setStroke(strokeWidth, strokeColor);
+        return drawable;
+    }
+
+    private int dp(int value) {
+        return Math.round(value * getResources().getDisplayMetrics().density);
+    }
+}

--- a/android-shell/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/android-shell/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#111827" />
+</shape>

--- a/android-shell/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android-shell/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M54,18C34.12,18 18,34.12 18,54C18,73.88 34.12,90 54,90C73.88,90 90,73.88 90,54C90,34.12 73.88,18 54,18ZM54,27C68.91,27 81,39.09 81,54C81,68.91 68.91,81 54,81C39.09,81 27,68.91 27,54C27,39.09 39.09,27 54,27Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M39,38H49.5C60.82,38 69,45.06 69,54C69,62.94 60.82,70 49.5,70H39V38ZM48.8,47V61H50.2C55.96,61 59.5,58.3 59.5,54C59.5,49.7 55.96,47 50.2,47H48.8Z" />
+</vector>

--- a/android-shell/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android-shell/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android-shell/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android-shell/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android-shell/app/src/main/res/mipmap-anydpi/ic_launcher.xml
+++ b/android-shell/app/src/main/res/mipmap-anydpi/ic_launcher.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#111827"
+        android:pathData="M24,8H84A16,16 0,0 1,100 24V84A16,16 0,0 1,84 100H24A16,16 0,0 1,8 84V24A16,16 0,0 1,24 8Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M54,22C36.33,22 22,36.33 22,54C22,71.67 36.33,86 54,86C71.67,86 86,71.67 86,54C86,36.33 71.67,22 54,22ZM54,31C66.7,31 77,41.3 77,54C77,66.7 66.7,77 54,77C41.3,77 31,66.7 31,54C31,41.3 41.3,31 54,31Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M39,38H49.5C60.82,38 69,45.06 69,54C69,62.94 60.82,70 49.5,70H39V38ZM48.8,47V61H50.2C55.96,61 59.5,58.3 59.5,54C59.5,49.7 55.96,47 50.2,47H48.8Z" />
+</vector>

--- a/android-shell/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
+++ b/android-shell/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#111827"
+        android:pathData="M54,6C27.49,6 6,27.49 6,54C6,80.51 27.49,102 54,102C80.51,102 102,80.51 102,54C102,27.49 80.51,6 54,6Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M54,22C36.33,22 22,36.33 22,54C22,71.67 36.33,86 54,86C71.67,86 86,71.67 86,54C86,36.33 71.67,22 54,22ZM54,31C66.7,31 77,41.3 77,54C77,66.7 66.7,77 54,77C41.3,77 31,66.7 31,54C31,41.3 41.3,31 54,31Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M39,38H49.5C60.82,38 69,45.06 69,54C69,62.94 60.82,70 49.5,70H39V38ZM48.8,47V61H50.2C55.96,61 59.5,58.3 59.5,54C59.5,49.7 55.96,47 50.2,47H48.8Z" />
+</vector>

--- a/android-shell/app/src/main/res/values/strings.xml
+++ b/android-shell/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">OpenCodex</string>
+</resources>

--- a/android-shell/app/src/main/res/values/styles.xml
+++ b/android-shell/app/src/main/res/values/styles.xml
@@ -1,0 +1,8 @@
+<resources>
+    <style name="AppTheme" parent="android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:fontFamily">sans</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:navigationBarColor">#ffffff</item>
+        <item name="android:colorAccent">#111827</item>
+    </style>
+</resources>

--- a/android-shell/app/src/main/res/xml/network_security_config.xml
+++ b/android-shell/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,3 @@
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>

--- a/android-shell/build.gradle
+++ b/android-shell/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id "com.android.application" version "8.7.3" apply false
+}

--- a/android-shell/settings.gradle
+++ b/android-shell/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "OpenCodexAndroidShell"
+include ":app"

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -4,160 +4,181 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>OpenCodex</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
-    <main class="shell">
-      <section class="topbar">
-        <div>
-          <p class="eyebrow">OpenCodex 启动器</p>
+    <!-- 极简顶部导航栏 -->
+    <header class="app-header">
+      <div class="header-inner">
+        <div class="header-brand">
+          <img class="logo" src="../web-shell/assets/icon.png" alt="Logo" />
           <h1 id="serviceTitle">本机服务</h1>
         </div>
         <div class="status-pill" id="statusPill">启动中</div>
-      </section>
+      </div>
+    </header>
 
-      <section class="hero">
-        <div class="service">
-          <div class="service-main">
-            <div class="label">访问地址</div>
+    <main class="app-main">
+      <div class="container">
+
+        <!-- 错误提示 -->
+        <div class="notice" id="lastError" hidden></div>
+
+        <!-- 顶部核心大动作区域 -->
+        <section class="hero-section">
+          <div class="hero-content">
+            <div class="hero-label">访问地址</div>
             <div class="url-list" id="lanUrls" hidden></div>
           </div>
-          <div class="actions">
+          <div class="hero-actions">
             <button class="primary" id="openCodex">打开 Codex</button>
             <button id="copyUrl">复制地址</button>
             <button id="restart">重启服务</button>
           </div>
-        </div>
-        <div class="notice" id="lastError" hidden></div>
-      </section>
+        </section>
 
-      <section class="panel settings-panel">
-        <div class="panel-head">
-          <h2>设置</h2>
-        </div>
-        <div class="settings-grid">
-          <div class="setting-block">
-            <div class="label">启动地址</div>
-            <div class="segmented" id="hostModeGroup">
-              <label>
-                <input type="radio" name="hostMode" value="local" />
-                <span>本机</span>
-              </label>
-              <label>
-                <input type="radio" name="hostMode" value="lan" />
-                <span>局域网</span>
-              </label>
+        <!-- 核心设置列表 -->
+        <section class="setting-section">
+          <h2>设置 <span class="section-caption">服务访问</span></h2>
+          <div class="setting-list">
+            <div class="setting-item">
+              <div class="setting-info">
+                <div class="setting-label">启动地址</div>
+                <div class="setting-desc">选择服务运行的接口绑定</div>
+              </div>
+              <div class="setting-control">
+                <div class="segmented" id="hostModeGroup">
+                  <label>
+                    <input type="radio" name="hostMode" value="local" />
+                    <span>本机</span>
+                  </label>
+                  <label>
+                    <input type="radio" name="hostMode" value="lan" />
+                    <span>局域网</span>
+                  </label>
+                </div>
+              </div>
             </div>
-          </div>
-          <div class="setting-block">
-            <div class="label">端口</div>
-            <div class="port-row">
-              <input id="portInput" type="number" min="1" max="65535" step="1" inputmode="numeric" />
-              <button id="savePort">保存端口</button>
-            </div>
-          </div>
-          <div class="setting-block">
-            <div class="label">访问密码</div>
-            <div class="password-row">
-              <input id="passwordInput" type="password" autocomplete="new-password" placeholder="留空关闭密码" />
-              <button id="savePassword">保存密码</button>
-              <button id="clearPassword">清空</button>
-            </div>
-            <div class="setting-status" id="authStatus">未启用</div>
-          </div>
-        </div>
-      </section>
 
-      <section class="grid">
-        <article class="panel">
-          <div class="panel-head">
-            <h2>Codex</h2>
-          </div>
-          <dl class="kv">
-            <div>
-              <dt>版本</dt>
-              <dd id="codexVersion">未知</dd>
+            <div class="setting-item">
+              <div class="setting-info">
+                <div class="setting-label">端口</div>
+                <div class="setting-desc">服务监听的网络端口</div>
+              </div>
+              <div class="setting-control port-row">
+                <input id="portInput" type="number" min="1" max="65535" step="1" inputmode="numeric" />
+                <button id="savePort">保存</button>
+              </div>
             </div>
-            <div>
-              <dt>构建</dt>
-              <dd id="codexBuild">未知</dd>
-            </div>
-            <div>
-              <dt>缓存时间</dt>
-              <dd id="cacheUpdatedAt">未知</dd>
-            </div>
-            <div>
-              <dt>Codex 路径</dt>
-              <dd><button class="path" id="codexAppPath">未找到</button></dd>
-            </div>
-            <div>
-              <dt>app.asar</dt>
-              <dd><button class="path" id="sourceAsarPath">未找到</button></dd>
-            </div>
-            <div>
-              <dt>命令行</dt>
-              <dd><button class="path" id="codexBinaryPath">未找到</button></dd>
-            </div>
-          </dl>
-        </article>
 
-        <article class="panel">
-          <div class="panel-head">
-            <h2>网关</h2>
+            <div class="setting-item">
+              <div class="setting-info">
+                <div class="setting-label">访问密码</div>
+                <div class="setting-desc">
+                  设置访问权限 - 当前状态: <span class="setting-status" id="authStatus">未启用</span>
+                </div>
+              </div>
+              <div class="setting-control password-row">
+                <input id="passwordInput" type="password" autocomplete="new-password" placeholder="留空关闭密码" />
+                <button id="savePassword">保存</button>
+                <button id="clearPassword">清空</button>
+              </div>
+            </div>
           </div>
-          <dl class="kv">
-            <div>
-              <dt>进程</dt>
-              <dd id="gatewayPid">未运行</dd>
-            </div>
-            <div>
-              <dt>启动时间</dt>
-              <dd id="gatewayStartedAt">未知</dd>
-            </div>
-            <div>
-              <dt>监听</dt>
-              <dd id="gatewayListen">127.0.0.1:3737</dd>
-            </div>
-            <div>
-              <dt>应用服务</dt>
-              <dd id="appServerMode">未知</dd>
-            </div>
-            <div>
-              <dt>Node</dt>
-              <dd id="nodeVersion">未知</dd>
-            </div>
-            <div>
-              <dt>Electron</dt>
-              <dd id="electronVersion">未知</dd>
-            </div>
-          </dl>
-        </article>
+        </section>
 
-        <article class="panel wide">
-          <div class="panel-head">
+        <!-- Codex 运行时 -->
+        <section class="setting-section">
+          <h2>Codex <span class="section-caption">官方运行时</span></h2>
+          <div class="setting-list kv">
+            <div class="setting-item">
+              <div class="setting-label">版本</div>
+              <div class="setting-value" id="codexVersion">未知</div>
+            </div>
+            <div class="setting-item">
+              <div class="setting-label">构建</div>
+              <div class="setting-value" id="codexBuild">未知</div>
+            </div>
+            <div class="setting-item">
+              <div class="setting-label">缓存时间</div>
+              <div class="setting-value" id="cacheUpdatedAt">未知</div>
+            </div>
+            <div class="setting-item">
+              <div class="setting-label">Codex 路径</div>
+              <div class="setting-control"><button class="path" id="codexAppPath">未找到</button></div>
+            </div>
+            <div class="setting-item">
+              <div class="setting-label">app.asar</div>
+              <div class="setting-control"><button class="path" id="sourceAsarPath">未找到</button></div>
+            </div>
+            <div class="setting-item">
+              <div class="setting-label">命令行</div>
+              <div class="setting-control"><button class="path" id="codexBinaryPath">未找到</button></div>
+            </div>
+          </div>
+        </section>
+
+        <!-- 网关状态 -->
+        <section class="setting-section">
+          <h2>网关 <span class="section-caption">本机进程</span></h2>
+          <div class="setting-list kv">
+            <div class="setting-item">
+              <div class="setting-label">进程</div>
+              <div class="setting-value" id="gatewayPid">未运行</div>
+            </div>
+            <div class="setting-item">
+              <div class="setting-label">启动时间</div>
+              <div class="setting-value" id="gatewayStartedAt">未知</div>
+            </div>
+            <div class="setting-item">
+              <div class="setting-label">监听</div>
+              <div class="setting-value" id="gatewayListen">127.0.0.1:3737</div>
+            </div>
+            <div class="setting-item">
+              <div class="setting-label">应用服务</div>
+              <div class="setting-value" id="appServerMode">未知</div>
+            </div>
+            <div class="setting-item">
+              <div class="setting-label">Node</div>
+              <div class="setting-value" id="nodeVersion">未知</div>
+            </div>
+            <div class="setting-item">
+              <div class="setting-label">Electron</div>
+              <div class="setting-value" id="electronVersion">未知</div>
+            </div>
+          </div>
+        </section>
+
+        <!-- 运行目录 -->
+        <section class="setting-section">
+          <div class="section-head">
             <h2>运行目录</h2>
-            <button id="openLogs">打开日志</button>
+            <button id="openLogs" class="secondary-btn">查看日志</button>
           </div>
-          <dl class="kv paths">
-            <div>
-              <dt>配置</dt>
-              <dd><button class="path" id="configPath">未创建</button></dd>
+          <div class="setting-list kv paths">
+            <div class="setting-item">
+              <div class="setting-label">配置</div>
+              <div class="setting-control"><button class="path" id="configPath">未创建</button></div>
             </div>
-            <div>
-              <dt>日志</dt>
-              <dd><button class="path" id="logPath">未创建</button></dd>
+            <div class="setting-item">
+              <div class="setting-label">日志</div>
+              <div class="setting-control"><button class="path" id="logPath">未创建</button></div>
             </div>
-            <div>
-              <dt>报告</dt>
-              <dd><button class="path" id="reportsDir">未创建</button></dd>
+            <div class="setting-item">
+              <div class="setting-label">报告</div>
+              <div class="setting-control"><button class="path" id="reportsDir">未创建</button></div>
             </div>
-            <div>
-              <dt>渲染器缓存</dt>
-              <dd><button class="path" id="officialBundleDir">未创建</button></dd>
+            <div class="setting-item">
+              <div class="setting-label">渲染器缓存</div>
+              <div class="setting-control"><button class="path" id="officialBundleDir">未创建</button></div>
             </div>
-          </dl>
-        </article>
-      </section>
+          </div>
+        </section>
+
+      </div>
     </main>
     <script src="./renderer.js"></script>
   </body>

--- a/desktop/styles.css
+++ b/desktop/styles.css
@@ -1,248 +1,335 @@
 :root {
   color-scheme: light;
-  --bg: #f4f7f6;
-  --surface: #ffffff;
-  --ink: #17201c;
-  --muted: #66736d;
-  --line: #dce4e0;
-  --accent: #0f7b63;
-  --accent-dark: #075945;
-  --warn-bg: #fff1dc;
-  --warn: #8a4f05;
-  --shadow: 0 16px 40px rgba(16, 35, 29, 0.08);
+  --bg-primary: #FFFFFF;
+  --bg-secondary: #F9F9F9;
+  --border-color: #E5E5E5;
+  --text-primary: #202123;
+  --text-secondary: #6E6E80;
+  --accent-color: #10A37F;
+  --accent-hover: #1A7F64;
+  --focus-ring: rgba(16, 163, 127, 0.4);
+  --btn-bg: #FFFFFF;
+  --btn-border: #D9D9E3;
+  --btn-hover: #ECECF1;
+  --pill-bg: #E7F6F1;
+  --pill-text: #10A37F;
+  --pill-offline-bg: #FEF0C7;
+  --pill-offline-text: #B54708;
+  --error-bg: #FEF3F2;
+  --error-text: #B42318;
+  --error-border: #FECDCA;
 }
 
 * {
   box-sizing: border-box;
 }
 
-body {
+html, body {
   margin: 0;
-  min-width: 760px;
+  padding: 0;
   min-height: 100vh;
-  font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  color: var(--ink);
-  background:
-    linear-gradient(180deg, rgba(15, 123, 99, 0.08), transparent 320px),
-    var(--bg);
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: 'Outfit', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  font-size: 14px;
+  -webkit-font-smoothing: antialiased;
 }
 
-button {
-  height: 34px;
-  padding: 0 12px;
-  border: 1px solid var(--line);
-  border-radius: 7px;
-  color: var(--ink);
-  background: #ffffff;
-  font: inherit;
-  font-size: 13px;
-  cursor: pointer;
+/* Header */
+.app-header {
+  border-bottom: 1px solid var(--border-color);
+  background-color: var(--bg-primary);
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
-input[type="password"],
-input[type="number"] {
-  width: 100%;
-  min-width: 0;
-  height: 34px;
-  padding: 0 11px;
-  border: 1px solid var(--line);
-  border-radius: 7px;
-  color: var(--ink);
-  background: #ffffff;
-  font: inherit;
-  font-size: 13px;
-}
-
-input[type="password"]:focus,
-input[type="number"]:focus {
-  border-color: var(--accent);
-  outline: 2px solid rgba(15, 123, 99, 0.14);
-}
-
-button:hover {
-  border-color: #9fb3ab;
-  background: #f9fbfa;
-}
-
-button.primary {
-  border-color: var(--accent);
-  color: #ffffff;
-  background: var(--accent);
-}
-
-button.primary:hover {
-  background: var(--accent-dark);
-}
-
-.shell {
-  width: min(1120px, calc(100vw - 56px));
+.header-inner {
+  max-width: 800px;
   margin: 0 auto;
-  padding: 34px 0 46px;
-}
-
-.topbar {
+  height: 60px;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  gap: 20px;
-  margin-bottom: 22px;
+  padding: 0 24px;
 }
 
-.eyebrow {
-  margin: 0 0 7px;
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0;
-  text-transform: uppercase;
+.header-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
-h1,
-h2 {
-  margin: 0;
-  letter-spacing: 0;
+.header-brand .logo {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
 }
 
-h1 {
-  font-size: 34px;
-  line-height: 1.12;
-}
-
-h2 {
+.header-brand h1 {
   font-size: 16px;
-  line-height: 1.2;
+  font-weight: 600;
+  margin: 0;
+  color: var(--text-primary);
 }
 
 .status-pill {
   display: inline-flex;
   align-items: center;
-  min-height: 30px;
-  padding: 0 12px;
-  border: 1px solid #bdd9ce;
-  border-radius: 999px;
-  color: var(--accent-dark);
-  background: #e8f5f0;
-  font-size: 13px;
-  font-weight: 700;
+  height: 24px;
+  padding: 0 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  background-color: var(--pill-bg);
+  color: var(--pill-text);
+  gap: 6px;
+}
+
+.status-pill::before {
+  content: "";
+  display: block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--accent-color);
 }
 
 .status-pill.offline {
-  border-color: #e9c58a;
-  color: var(--warn);
-  background: var(--warn-bg);
+  background-color: var(--pill-offline-bg);
+  color: var(--pill-offline-text);
 }
 
-.hero,
-.panel {
-  border: 1px solid var(--line);
+.status-pill.offline::before {
+  background-color: #F79009;
+}
+
+/* Main Container */
+.app-main {
+  padding: 40px 24px 80px;
+}
+
+.container {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.notice {
+  margin-bottom: 24px;
+  padding: 12px 16px;
   border-radius: 8px;
-  background: var(--surface);
-  box-shadow: var(--shadow);
+  background-color: var(--error-bg);
+  color: var(--error-text);
+  border: 1px solid var(--error-border);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13px;
+  line-height: 1.5;
 }
 
-.hero {
-  padding: 22px;
-  margin-bottom: 18px;
-}
-
-.service {
+/* Hero Section */
+.hero-section {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 24px;
+  padding-bottom: 32px;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 40px;
+  gap: 20px;
+  flex-wrap: wrap;
 }
 
-.service-main {
-  min-width: 0;
-}
-
-.label {
+.hero-label {
+  font-size: 13px;
+  color: var(--text-secondary);
+  font-weight: 500;
   margin-bottom: 8px;
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 700;
 }
 
 .url-list {
   display: flex;
-  flex-wrap: wrap;
   gap: 8px;
-  margin-top: 0;
+  flex-wrap: wrap;
 }
 
 .url-chip {
-  max-width: 100%;
-  height: 40px;
-  padding: 0 16px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: 18px;
+  display: inline-flex;
+  align-items: center;
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 6px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13.5px;
+  color: var(--text-primary);
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--btn-border);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
 }
 
-.actions {
+.url-chip:hover {
+  background-color: var(--btn-hover);
+}
+
+.hero-actions {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
+  gap: 12px;
+}
+
+/* Buttons */
+button {
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  height: 36px;
+  padding: 0 16px;
+  border-radius: 6px;
+  border: 1px solid var(--btn-border);
+  background-color: var(--btn-bg);
+  color: var(--text-primary);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s ease;
+}
+
+button:hover {
+  background-color: var(--btn-hover);
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--focus-ring);
+  border-color: var(--accent-color);
+}
+
+button.primary {
+  background-color: var(--accent-color);
+  color: #FFFFFF;
+  border-color: transparent;
+}
+
+button.primary:hover {
+  background-color: var(--accent-hover);
+}
+
+/* Setting Sections */
+.setting-section {
+  margin-bottom: 56px;
+}
+
+.setting-section h2 {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 24px 0;
+  color: var(--text-primary);
+  display: flex;
+  align-items: baseline;
   gap: 8px;
-  min-width: 320px;
 }
 
-.notice {
-  margin-top: 16px;
-  padding: 12px;
-  border: 1px solid #f0d09b;
-  border-radius: 7px;
-  color: var(--warn);
-  background: var(--warn-bg);
+.section-caption {
   font-size: 13px;
-  line-height: 1.45;
+  font-weight: 400;
+  color: var(--text-secondary);
 }
 
-.grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 18px;
+.section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
 }
 
-.panel {
+.section-head h2 {
+  margin-bottom: 0;
+}
+
+/* Setting List */
+.setting-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.setting-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border-color);
+  gap: 32px;
+}
+
+.setting-item:first-child {
+  border-top: 1px solid var(--border-color);
+}
+
+.setting-info {
+  flex: 1;
   min-width: 0;
-  padding: 18px;
 }
 
-.panel.wide {
-  grid-column: 1 / -1;
+.setting-label {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--text-primary);
+  margin-bottom: 6px;
 }
 
-.settings-panel {
-  margin-bottom: 18px;
+.setting-desc {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.5;
 }
 
-.settings-grid {
-  display: grid;
-  grid-template-columns: minmax(220px, 0.75fr) minmax(210px, 0.65fr) minmax(0, 1.2fr);
-  gap: 18px;
+.setting-status {
+  font-weight: 600;
 }
 
-.setting-block {
-  min-width: 0;
+.setting-control {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
 }
 
+/* Inputs */
+input[type="number"],
+input[type="password"] {
+  font-family: inherit;
+  font-size: 14px;
+  height: 36px;
+  padding: 0 12px;
+  border-radius: 6px;
+  border: 1px solid var(--btn-border);
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  width: 220px;
+  transition: all 0.15s ease;
+}
+
+input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 2px var(--focus-ring);
+}
+
+/* Segmented */
 .segmented {
-  display: inline-grid;
-  grid-template-columns: 1fr 1fr;
-  min-width: 240px;
-  overflow: hidden;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: #f7faf8;
+  display: inline-flex;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--btn-border);
+  border-radius: 6px;
+  padding: 3px;
 }
 
 .segmented label {
-  display: block;
-  min-width: 0;
+  position: relative;
+  margin: 0;
 }
 
 .segmented input {
@@ -255,125 +342,107 @@ h2 {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 34px;
-  padding: 0 14px;
-  color: var(--muted);
+  height: 30px;
+  padding: 0 16px;
+  border-radius: 4px;
   font-size: 13px;
-  font-weight: 700;
+  font-weight: 500;
+  color: var(--text-secondary);
   cursor: pointer;
+  transition: all 0.15s ease;
 }
 
 .segmented input:checked + span {
-  color: #ffffff;
-  background: var(--accent);
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
-.password-row {
-  display: grid;
-  grid-template-columns: minmax(180px, 1fr) auto auto;
-  gap: 8px;
-}
-
-.port-row {
-  display: grid;
-  grid-template-columns: minmax(120px, 1fr) auto;
-  gap: 8px;
-}
-
-.setting-status {
-  margin-top: 8px;
-  color: var(--muted);
-  font-size: 13px;
-}
-
-.panel-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 14px;
-}
-
-.kv {
-  display: grid;
-  gap: 10px;
-  margin: 0;
-}
-
-.kv > div {
-  display: grid;
-  grid-template-columns: 120px minmax(0, 1fr);
-  gap: 12px;
-  align-items: center;
-  min-height: 34px;
-}
-
-.kv dt {
-  color: var(--muted);
-  font-size: 13px;
-}
-
-.kv dd {
-  min-width: 0;
-  margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 13px;
+/* Value Display / Path Button */
+.setting-value {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13.5px;
+  color: var(--text-primary);
 }
 
 .path {
-  display: block;
-  width: 100%;
-  min-width: 0;
-  height: 32px;
-  padding: 0;
-  overflow: hidden;
-  border: 0;
-  color: var(--ink);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13.5px;
+  color: var(--text-secondary);
   background: transparent;
-  text-align: left;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  border: none;
+  padding: 0;
+  height: auto;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+  transition: color 0.15s, text-decoration-color 0.15s;
 }
 
 .path:hover {
-  color: var(--accent-dark);
+  color: var(--accent-color);
   background: transparent;
+  text-decoration-color: var(--accent-color);
+  transform: none;
 }
 
-.paths > div {
-  grid-template-columns: 140px minmax(0, 1fr);
+.path:focus-visible {
+  box-shadow: none;
+  border-color: transparent;
+  text-decoration-color: var(--accent-color);
 }
 
-@media (max-width: 860px) {
-  .shell {
-    width: calc(100vw - 32px);
-  }
+/* KV Overrides */
+.kv .setting-item {
+  padding: 16px 0;
+}
+.kv .setting-label {
+  color: var(--text-secondary);
+  font-weight: 400;
+  margin-bottom: 0;
+  flex: 0 0 140px;
+}
+.kv .setting-value,
+.kv .setting-control {
+  flex: 1;
+  justify-content: flex-end;
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+}
 
-  .service,
-  .topbar {
-    align-items: stretch;
+.paths .setting-label {
+  flex: 0 0 140px;
+}
+
+@media (max-width: 640px) {
+  .hero-section {
     flex-direction: column;
+    align-items: flex-start;
   }
-
-  .actions {
-    justify-content: flex-start;
-    min-width: 0;
+  .setting-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
   }
-
-  .grid {
-    grid-template-columns: 1fr;
-  }
-
-  .settings-grid,
-  .password-row,
-  .port-row {
-    grid-template-columns: 1fr;
-  }
-
-  .segmented {
+  .setting-control {
     width: 100%;
+    justify-content: flex-start;
+  }
+  input[type="number"],
+  input[type="password"] {
+    width: 100%;
+    flex: 1;
+  }
+  .kv .setting-item {
+    flex-direction: row;
+    align-items: center;
+  }
+  .kv .setting-value,
+  .kv .setting-control {
+    text-align: right;
   }
 }

--- a/gateway/src/codex-app-server.ts
+++ b/gateway/src/codex-app-server.ts
@@ -79,6 +79,9 @@ function createJsonRpcClient(sendFn) {
 }
 
 function shellQuote(value) {
+  if (process.platform === "win32") {
+    return `"${String(value).replace(/"/g, '\\"')}"`;
+  }
   return `'${String(value).replace(/'/g, "'\\''")}'`;
 }
 

--- a/gateway/src/ipc/codex/GatewayCodexIpcPort.ts
+++ b/gateway/src/ipc/codex/GatewayCodexIpcPort.ts
@@ -875,6 +875,8 @@ function makeHandlers({ appServer, broadcast, logger, isClientConnected }) {
         return appServerBridge.callAppServer("git/status", payload);
       case "gh-cli-status":
         return gitIpc.ghCliStatus();
+      case "gh-pr-status":
+        return gitIpc.ghPrStatusForPayload(payload || {});
       case "stable-metadata":
         return gitIpc.gitStableMetadataForPayload(payload || {});
       case "apply-patch":

--- a/gateway/src/ipc/codex/appServerBridge.ts
+++ b/gateway/src/ipc/codex/appServerBridge.ts
@@ -6,6 +6,7 @@ const {
   enrichThreadForReviewDiff,
   enrichTurnListForReviewDiff,
 } = require("./reviewDiffSnapshots");
+const path = require("path");
 
 function createAppServerBridge(deps) {
   const appServer = deps.appServer;
@@ -81,10 +82,36 @@ function createAppServerBridge(deps) {
     return result;
   }
 
+  function normalizeWindowsThreadFilePath(value) {
+    if (process.platform !== "win32" || typeof value !== "string" || !value.trim()) return value;
+    const trimmed = value.trim();
+    if (trimmed.startsWith("\\\\?\\")) return trimmed;
+    if (!/^[A-Za-z]:[\\/]/.test(trimmed)) return value;
+    return path.toNamespacedPath(path.resolve(trimmed));
+  }
+
+  function normalizeThreadResumePayload(value, key = "") {
+    if (Array.isArray(value)) return value.map((entry) => normalizeThreadResumePayload(entry, key));
+    if (!value || typeof value !== "object") {
+      return /(?:^|\.)(path|sessionPath|threadPath)$/i.test(key) ? normalizeWindowsThreadFilePath(value) : value;
+    }
+    let changed = false;
+    const next = {};
+    for (const [entryKey, entryValue] of Object.entries(value)) {
+      const normalized = normalizeThreadResumePayload(entryValue, key ? `${key}.${entryKey}` : entryKey);
+      next[entryKey] = normalized;
+      if (normalized !== entryValue) changed = true;
+    }
+    return changed ? next : value;
+  }
+
   /** 转发业务请求到 app-server，并统一记录失败日志。 */
   async function callAppServer(method, payload, options = {}) {
     const appServerMethod = APP_SERVER_METHOD_ALIASES.get(method) || method;
     let appServerPayload = payload;
+    if (appServerMethod === "thread/resume" || appServerMethod === "thread/read") {
+      appServerPayload = normalizeThreadResumePayload(payload);
+    }
     if (appServerMethod === "experimentalFeature/enablement/set") {
       const filtered = filterUnsupportedFeatureEnablements(payload);
       appServerPayload = filtered.payload;

--- a/gateway/src/ipc/codex/channelRegistry.ts
+++ b/gateway/src/ipc/codex/channelRegistry.ts
@@ -618,6 +618,7 @@ const CODEX_ADDITIONAL_CHANNELS = [
   "git-checkout-branch",
   "git-create-branch",
   "gh-cli-status",
+  "gh-pr-status",
   "ide-context",
   "install-recommended-skill",
   "list-experimental-features",

--- a/gateway/src/ipc/codex/git.ts
+++ b/gateway/src/ipc/codex/git.ts
@@ -1282,7 +1282,7 @@ function createGitIpcHandlers(deps) {
   }
 
   /** 执行本机命令并只返回结果，stdout/stderr 不落日志，避免泄露用户环境细节。 */
-  function runQuietCommand(command, args, timeoutMs) {
+  function runQuietCommand(command, args, timeoutMs, options = {}) {
     try {
       return {
         ok: true,
@@ -1290,10 +1290,50 @@ function createGitIpcHandlers(deps) {
           encoding: "utf8",
           stdio: ["ignore", "pipe", "ignore"],
           timeout: timeoutMs,
+          cwd: options.cwd,
+          maxBuffer: options.maxBuffer || 1024 * 1024,
         }),
       };
     } catch {
       return { ok: false, stdout: "" };
+    }
+  }
+
+  function emptyGhPrStatus(extra = {}) {
+    return {
+      status: "success",
+      activityItems: [],
+      boardItem: null,
+      body: "",
+      canMerge: false,
+      checks: [],
+      ciStatus: "none",
+      commentAttachments: [],
+      hasOpenPr: false,
+      isDraft: false,
+      number: null,
+      repo: null,
+      reviewers: {
+        approved: [],
+        commentCounts: [],
+        commented: [],
+        changesRequested: [],
+        requested: [],
+        unresolvedCommentCount: 0,
+      },
+      reviewStatus: "none",
+      title: null,
+      url: null,
+      ...extra,
+    };
+  }
+
+  function parseJsonObject(text) {
+    try {
+      const parsed = JSON.parse(String(text || ""));
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+    } catch {
+      return null;
     }
   }
 
@@ -1310,6 +1350,64 @@ function createGitIpcHandlers(deps) {
       isAuthenticated: authResult.ok,
       version,
     };
+  }
+
+  /** gh-pr-status IPC：best-effort 查询当前分支对应的 GitHub PR；失败时返回稳定的“无 PR”结构。 */
+  function ghPrStatusForPayload(payload) {
+    const params = payloadParams(payload);
+    const target = resolveGitTargetPath(params);
+    const gitRoot = target ? findGitRoot(target) : null;
+    const headBranch =
+      params && typeof params === "object" && typeof params.headBranch === "string"
+        ? params.headBranch.trim()
+        : "";
+    const fallback = emptyGhPrStatus();
+    if (!gitRoot || !headBranch) return fallback;
+
+    const status = ghCliStatus();
+    if (!status.isInstalled || !status.isAuthenticated) return fallback;
+
+    const result = runQuietCommand(
+      "gh",
+      [
+        "pr",
+        "view",
+        headBranch,
+        "--json",
+        "number,url,title,body,isDraft,mergeable,reviewDecision,repository,state",
+      ],
+      5000,
+      { cwd: gitRoot }
+    );
+    if (!result.ok) return fallback;
+
+    const pr = parseJsonObject(result.stdout);
+    if (!pr || typeof pr.number !== "number") return fallback;
+
+    const reviewDecision = String(pr.reviewDecision || "").toUpperCase();
+    const reviewStatus =
+      reviewDecision === "APPROVED"
+        ? "approved"
+        : reviewDecision === "CHANGES_REQUESTED"
+          ? "changes_requested"
+          : "none";
+    const mergeable = String(pr.mergeable || "").toUpperCase();
+    const repo =
+      pr.repository && typeof pr.repository === "object"
+        ? pr.repository.nameWithOwner || pr.repository.name || null
+        : null;
+
+    return emptyGhPrStatus({
+      body: typeof pr.body === "string" ? pr.body : "",
+      canMerge: mergeable === "MERGEABLE",
+      hasOpenPr: String(pr.state || "").toUpperCase() !== "CLOSED",
+      isDraft: !!pr.isDraft,
+      number: pr.number,
+      repo,
+      reviewStatus,
+      title: typeof pr.title === "string" ? pr.title : null,
+      url: typeof pr.url === "string" ? pr.url : null,
+    });
   }
 
 
@@ -1386,6 +1484,7 @@ function createGitIpcHandlers(deps) {
     createGitBranchForPayload,
     currentBranchForPayload,
     ghCliStatus,
+    ghPrStatusForPayload,
     gitStableMetadataForPayload,
     gitStatusForPayload,
     handleGitWorkerMethod,

--- a/gateway/src/ipc/codex/viewMessages.ts
+++ b/gateway/src/ipc/codex/viewMessages.ts
@@ -238,6 +238,11 @@ function createViewMessageHandlers(deps) {
         await appServerBridge.respondToAppServerRequest(payload);
         return true;
       }
+      if (payload.type === "thread-queued-followups-changed") {
+        // Renderer-local queue state notification. Desktop persists/observes this on the Electron side;
+        // the web gateway only needs to ACK it so the renderer does not surface a warning toast.
+        return true;
+      }
       if (String(payload.type || "").startsWith("terminal-")) {
         const handled = terminalIpc.handleTerminalMessage(payload, context);
         if (!handled) {

--- a/gateway/src/official/AsarWebviewExtractor.ts
+++ b/gateway/src/official/AsarWebviewExtractor.ts
@@ -49,15 +49,16 @@ class AsarWebviewExtractor {
     let byteCount = 0;
 
     for (const rawEntry of entries) {
-      const entry = String(rawEntry).replace(/^\/+/, "");
+      const archiveEntry = String(rawEntry).replace(/^[\\/]+/, "");
+      const entry = archiveEntry.replace(/\\/g, "/");
       if (!entry.startsWith("webview/")) continue;
       const rel = entry.slice("webview/".length);
       if (!rel) continue;
 
-      const stat = this.archive.statFile(asarPath, entry);
+      const stat = this.archive.statFile(asarPath, archiveEntry);
       if (stat && stat.files) continue;
 
-      const data = this.archive.extractFile(asarPath, entry);
+      const data = this.archive.extractFile(asarPath, archiveEntry);
       const dest = this.pathGuard.resolve(webviewDestDir, rel);
       this.fileSystem.writeFile(dest, data);
       fileCount += 1;

--- a/gateway/src/official/CodexAsarScanner.ts
+++ b/gateway/src/official/CodexAsarScanner.ts
@@ -3,6 +3,7 @@ export {};
 
 const path = require("path");
 const os = require("os");
+const { execFileSync } = require("child_process");
 const { ASAR_FILE_NAME } = require("./constants");
 const { OfficialBundleFileSystem } = require("./OfficialBundleFileSystem");
 
@@ -51,6 +52,7 @@ class CodexAsarCandidateProvider {
         this.env.LOCALAPPDATA && path.join(this.env.LOCALAPPDATA, "Programs", "Codex", "resources"),
         this.env.PROGRAMFILES && path.join(this.env.PROGRAMFILES, "Codex"),
         this.env["PROGRAMFILES(X86)"] && path.join(this.env["PROGRAMFILES(X86)"], "Codex"),
+        ...this.windowsAppsCandidates(),
       ]);
     }
     return [
@@ -66,6 +68,52 @@ class CodexAsarCandidateProvider {
   private uniqueNonEmpty(values: Array<string | null | undefined>): string[] {
     return Array.from(new Set(values.filter((value) => typeof value === "string" && value.trim()).map(String)));
   }
+
+  private windowsAppsCandidates(): string[] {
+    const appxInstallLocation = this.codexAppxInstallLocation();
+    if (appxInstallLocation) {
+      const appDir = path.join(appxInstallLocation, "app");
+      return [appDir, path.join(appDir, "resources")];
+    }
+
+    const windowsAppsDir = this.env.PROGRAMFILES && path.join(this.env.PROGRAMFILES, "WindowsApps");
+    if (!windowsAppsDir || !this.fileSystem.isDirectory(windowsAppsDir)) return [];
+    try {
+      return this.fileSystem
+        .readDir(windowsAppsDir, { withFileTypes: true })
+        .filter((entry) => entry && entry.isDirectory && entry.isDirectory() && entry.name.startsWith("OpenAI.Codex_"))
+        .sort((a, b) => String(b.name).localeCompare(String(a.name)))
+        .flatMap((entry) => {
+          const appDir = path.join(windowsAppsDir, entry.name, "app");
+          return [appDir, path.join(appDir, "resources")];
+        });
+    } catch {
+      return [];
+    }
+  }
+
+  private codexAppxInstallLocation(): string {
+    try {
+      const output = execFileSync(
+        "powershell.exe",
+        [
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-Command",
+          "Get-AppxPackage -Name OpenAI.Codex | Select-Object -ExpandProperty InstallLocation",
+        ],
+        {
+          encoding: "utf8",
+          windowsHide: true,
+          timeout: 3000,
+        }
+      );
+      return String(output || "").split(/\r?\n/).find((line) => line.trim())?.trim() || "";
+    } catch {
+      return "";
+    }
+  }
 }
 
 /** 只在 CLI 常见位置查找可执行文件，避免把安装根目录的 Electron 桌面入口当作 app-server 命令。 */
@@ -73,12 +121,15 @@ class CodexBinaryLocator {
   constructor({
     fileSystem,
     platform = process.platform,
+    env = process.env,
   }: {
     fileSystem: OfficialBundleFileSystem;
     platform?: string;
+    env?: Record<string, string | undefined>;
   }) {
     this.fileSystem = fileSystem;
     this.platform = platform;
+    this.env = env;
   }
 
   find({
@@ -100,6 +151,7 @@ class CodexBinaryLocator {
   }): string[] {
     if (this.platform === "win32") {
       return [
+        ...this.localOpenAICodexCliCandidates(),
         path.join(resourcesDir, "codex.exe"),
         path.join(resourcesDir, "Codex.exe"),
         path.join(resourcesDir, "codex.cmd"),
@@ -112,6 +164,19 @@ class CodexBinaryLocator {
       path.join(installRoot, "Contents", "Resources", "codex"),
       path.join(installRoot, "codex"),
     ];
+  }
+
+  private localOpenAICodexCliCandidates(): string[] {
+    const binDir = this.env.LOCALAPPDATA && path.join(this.env.LOCALAPPDATA, "OpenAI", "Codex", "bin");
+    if (!binDir || !this.fileSystem.isDirectory(binDir)) return [];
+    const nestedCandidates = [];
+    try {
+      for (const entry of this.fileSystem.readDir(binDir, { withFileTypes: true })) {
+        if (!entry || !entry.isDirectory || !entry.isDirectory()) continue;
+        nestedCandidates.push(path.join(binDir, entry.name, "codex.exe"));
+      }
+    } catch {}
+    return [...nestedCandidates.sort().reverse(), path.join(binDir, "codex.exe")];
   }
 }
 

--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -562,6 +562,7 @@ function createWebShellIndexResponse() {
 }
 
 function isPublicOfficialAsset(reqPath) {
+  if (reqPath === "/favicon.ico" || reqPath.startsWith(WEB_SHELL_ASSETS_PREFIX)) return true;
   if (/^\/official-patched\/assets\/[^/]+$/.test(reqPath)) return true;
   return /^\/official\/assets\/[^/]+\.(?:css|woff2?|ttf|otf)$/.test(reqPath);
 }
@@ -620,6 +621,7 @@ function patchOfficialAsset(reqPath, data) {
 
 /** 将 URL path 映射到 web-shell 或官方 asset 的真实文件。 */
 function staticFile(reqPath) {
+  if (reqPath === "/favicon.ico") return path.join(WEB_SHELL_DIR, "assets", "icon.png");
   if (reqPath === "/codex-bridge-polyfill.js") return path.join(WEB_SHELL_DIR, "codex-bridge-polyfill.js");
   if (reqPath === "/codex-tooltip-dismiss-guard.js") return path.join(WEB_SHELL_DIR, "codex-tooltip-dismiss-guard.js");
   if (reqPath.startsWith(WEB_SHELL_ASSETS_PREFIX)) {

--- a/gateway/src/server.ts
+++ b/gateway/src/server.ts
@@ -69,6 +69,7 @@ const LOCAL_FILE_TOKEN_TTL_MS = Math.max(1_000, Number(process.env.CODEX_WEB_LOC
 const PATCHED_OFFICIAL_PREFIX = "/official-patched/";
 let officialBundle = null;
 let hasWarnedHistoryPatchMiss = false;
+let hasWarnedAppShellViewportPatchMiss = false;
 // AsyncLocalStorage 用来把当前请求的 clientId/remoteAddress 传入更深层的 IPC handler。
 const requestContext = new AsyncLocalStorage();
 // 这些 channel 必须优先定向回触发请求的浏览器，避免局域网多设备访问时互相收到审批/fetch 响应。
@@ -596,7 +597,7 @@ function patchAppServerManagerSignalsChunk(source) {
     /turnStartedAtMs:([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\.startedAt\),firstTurnWorkItemStartedAtMs:\1\(\2\.firstTurnWorkItemStartedAt\?\?\2\.startedAt\),finalAssistantStartedAtMs:\1\(\2\.completedAt\)/;
   if (alreadyPatched.test(source)) return source;
   const historyTurnShape =
-    /(turnStartedAtMs:([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\.startedAt\),)(finalAssistantStartedAtMs:\2\(\3\.completedAt\),status:\3\.status)/;
+    /(turnStartedAtMs:([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\.startedAt\),)((?:durationMs:\3\.durationMs,)?)(finalAssistantStartedAtMs:\2\(\3\.completedAt\),status:\3\.status)/;
   if (!historyTurnShape.test(source)) {
     if (!hasWarnedHistoryPatchMiss) {
       hasWarnedHistoryPatchMiss = true;
@@ -604,18 +605,49 @@ function patchAppServerManagerSignalsChunk(source) {
     }
     return source;
   }
-  return source.replace(historyTurnShape, (_match, prefix, secondsToMs, turnVar, suffix) =>
-    `${prefix}firstTurnWorkItemStartedAtMs:${secondsToMs}(${turnVar}.firstTurnWorkItemStartedAt??${turnVar}.startedAt),${suffix}`
+  return source.replace(historyTurnShape, (_match, prefix, secondsToMs, turnVar, optionalDuration, suffix) =>
+    `${prefix}firstTurnWorkItemStartedAtMs:${secondsToMs}(${turnVar}.firstTurnWorkItemStartedAt??${turnVar}.startedAt),${optionalDuration}${suffix}`
   );
+}
+
+/**
+ * 官方 app-shell 是 Electron 桌面 renderer，根布局内联使用 100vw/100vh。
+ * 移动端浏览器软键盘、iOS 顶部状态栏避让只改变 visualViewport，
+ * 不稳定改变 layout viewport；如果继续用 100vh，composer、popover、dialog
+ * 都会按桌面视口布局到可视区域外。
+ *
+ * 这里只把 app-shell 的根 viewport 来源换成 web-shell 维护的 CSS 变量。
+ * 不碰 thread-scroll-container：官方线程滚动是 flex-col-reverse + 负 scrollTop 模型。
+ */
+function patchAppShellViewportChunk(source) {
+  const original =
+    "width:`calc(100vw / var(--codex-window-zoom))`,height:`calc(100vh / var(--codex-window-zoom))`";
+  const replacement =
+    "width:`calc(var(--codex-layout-viewport-width, 100vw) / var(--codex-window-zoom))`,height:`calc(var(--codex-layout-viewport-height, 100dvh) / var(--codex-window-zoom))`";
+  if (source.includes(replacement)) return source;
+  if (!source.includes(original)) {
+    if (!hasWarnedAppShellViewportPatchMiss) {
+      hasWarnedAppShellViewportPatchMiss = true;
+      console.warn("[gateway] app-shell mobile viewport patch skipped: current bundle shape did not match");
+    }
+    return source;
+  }
+  return source.replace(original, replacement);
 }
 
 /** 对官方 chunk 做响应期 patch，不落盘改 vendor/官方构建产物。 */
 function patchOfficialAsset(reqPath, data) {
   if (!shouldPatchOfficialAsset(reqPath)) return data;
   const source = data.toString("utf-8");
-  const patched = /\/app-server-manager-signals-[^/]+\.js$/.test(reqPath)
-    ? patchAppServerManagerSignalsChunk(source)
-    : source;
+  let patched = source;
+  if (/\/app-server-manager-signals-[^/]+\.js$/.test(reqPath)) {
+    patched = patchAppServerManagerSignalsChunk(patched);
+  }
+  // Keep the app-shell viewport aligned to visualViewport on mobile; this is
+  // required for composer placement when iOS changes the visible viewport.
+  if (source.includes("width:`calc(100vw / var(--codex-window-zoom))`")) {
+    patched = patchAppShellViewportChunk(patched);
+  }
   return Buffer.from(patched, "utf-8");
 }
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "test:vendor": "pnpm --dir vendor/electron-to-web run test",
     "desktop:dev": "pnpm run build && pnpm exec electron .",
     "desktop:pack:mac": "pnpm run build && pnpm exec electron-builder --mac --dir",
-    "desktop:dist:mac": "pnpm run build && pnpm exec electron-builder --mac dmg zip"
+    "desktop:dist:mac": "pnpm run build && pnpm exec electron-builder --mac dmg zip",
+    "desktop:pack:win": "pnpm run build && pnpm exec electron-builder --win --dir --x64 --config.npmRebuild=false --config.win.signAndEditExecutable=false",
+    "desktop:dist:win": "pnpm run build && pnpm exec electron-builder --win nsis portable --x64 --config.npmRebuild=false --config.win.signAndEditExecutable=false"
   },
   "dependencies": {
     "@electron/asar": "^4.1.2",
@@ -23,6 +25,7 @@
     "better-sqlite3": "^12.8.0",
     "brace-expansion": "^5.0.6",
     "express": "^5.2.1",
+    "json-rpc-2.0": "^1.7.1",
     "node-pty": "^1.1.0",
     "smol-toml": "^1.5.2",
     "tslib": "^2.8.1",
@@ -49,8 +52,15 @@
       "node_modules/**/*",
       "web-shell/**/*",
       "vendor/electron-to-web/dist/**/*",
-      "vendor/electron-to-web/node_modules/**/*",
-      "vendor/electron-to-web/package.json"
+      "vendor/electron-to-web/package.json",
+      {
+        "from": "vendor/electron-to-web/node_modules/.pnpm/json-rpc-2.0@1.7.1/node_modules/json-rpc-2.0",
+        "to": "node_modules/json-rpc-2.0",
+        "filter": [
+          "**/*"
+        ]
+      },
+      "!vendor/electron-to-web/node_modules/**/*"
     ],
     "mac": {
       "category": "public.app-category.developer-tools",
@@ -70,6 +80,27 @@
           ]
         }
       ]
+    },
+    "win": {
+      "signAndEditExecutable": false,
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "portable",
+          "arch": [
+            "x64"
+          ]
+        }
+      ]
+    },
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true
     }
   }
 }

--- a/web-shell/codex-bridge-polyfill.js
+++ b/web-shell/codex-bridge-polyfill.js
@@ -11,6 +11,7 @@
   const OPENCODEX_LANGUAGES = [OPENCODEX_LOCALE, "zh-CN", "zh", "en-US", "en"];
   const AUTH_FORCE_LOGIN_STORAGE_KEY = "codex_web_force_login";
   const OPENCODEX_SETTINGS_STORAGE_KEY = "opencodex_web_settings_v1";
+  const OPENCODEX_MOBILE_COMPOSER_DEBUG_STORAGE_KEY = "opencodex_debug_mobile_composer";
   const GATEWAY_AUTH_LOGOUT_LABEL = "退出认证";
   const GATEWAY_AUTH_LOGOUT_BUSY_LABEL = "正在退出认证...";
   const OFFICIAL_LOGOUT_LABELS = [
@@ -65,6 +66,22 @@
 
   function opencodexSettingEnabled(key) {
     return opencodexSettings()[key] !== false;
+  }
+
+  function mobileComposerDebugEnabled() {
+    try {
+      const value = localStorage.getItem(OPENCODEX_MOBILE_COMPOSER_DEBUG_STORAGE_KEY);
+      return value != null && value !== "0" && value !== "false";
+    } catch {
+      return false;
+    }
+  }
+
+  function debugMobileComposer(message, details = {}) {
+    if (!mobileComposerDebugEnabled()) return;
+    try {
+      console.info(`[opencodex:mobile-composer] ${message}`, details);
+    } catch {}
   }
 
   function gatewayAuthHeaders(headers) {
@@ -128,26 +145,90 @@
   installLocaleOverride();
   installRandomUUIDPolyfill();
 
-  function installMobileViewportGuards() {
-    if (!document || document.__codexMobileViewportGuardsInstalled) return;
-    document.__codexMobileViewportGuardsInstalled = true;
+  function installMobileViewportAdapter() {
+    if (!document || document.__codexMobileViewportAdapterInstalled) return;
+    document.__codexMobileViewportAdapterInstalled = true;
 
     const style = document.createElement("style");
-    style.id = "codex-mobile-viewport-guards";
+    style.id = "codex-mobile-viewport-adapter";
     style.textContent = `
+      :root {
+        --codex-layout-viewport-left: 0px;
+        --codex-layout-viewport-top: 0px;
+        --codex-layout-viewport-width: 100vw;
+        --codex-layout-viewport-height: 100dvh;
+      }
+
       @media (max-width: 820px), (pointer: coarse) {
         html {
-          scroll-padding-top: calc(var(--codex-visual-viewport-offset-top, 0px) + env(safe-area-inset-top) + 12px);
-          scroll-padding-bottom: calc(var(--codex-keyboard-inset-bottom, 0px) + env(safe-area-inset-bottom) + 112px);
+          position: fixed !important;
+          inset: 0 !important;
+          width: 100% !important;
+          min-width: 0 !important;
+          max-width: 100% !important;
+          height: 100% !important;
+          min-height: 100% !important;
+          max-height: 100% !important;
+          overflow: hidden !important;
           -webkit-text-size-adjust: 100%;
           text-size-adjust: 100%;
         }
 
         body {
-          width: 100%;
-          min-height: 100dvh;
-          touch-action: pan-x pan-y;
-          overscroll-behavior-y: contain;
+          position: fixed !important;
+          top: var(--codex-layout-viewport-top, 0px) !important;
+          left: var(--codex-layout-viewport-left, 0px) !important;
+          width: var(--codex-layout-viewport-width, 100vw) !important;
+          min-width: 0 !important;
+          max-width: var(--codex-layout-viewport-width, 100vw) !important;
+          height: var(--codex-layout-viewport-height, 100dvh) !important;
+          min-height: var(--codex-layout-viewport-height, 100dvh) !important;
+          max-height: var(--codex-layout-viewport-height, 100dvh) !important;
+          margin: 0 !important;
+          overflow: hidden !important;
+          overscroll-behavior: none;
+        }
+
+        #root {
+          width: 100% !important;
+          min-width: 0 !important;
+          max-width: 100% !important;
+          height: 100% !important;
+          min-height: 100% !important;
+          max-height: 100% !important;
+          overflow: hidden !important;
+        }
+
+        @supports selector(:has(*)) {
+          html:has(.app-shell-left-panel) .app-header-tint,
+          html:has([data-app-shell-focus-area="right-panel"]) .app-header-tint {
+            min-width: 0 !important;
+            overflow: hidden !important;
+          }
+
+          html:has(.app-shell-left-panel) .app-header-tint [data-test-id="header-shell-slot"],
+          html:has([data-app-shell-focus-area="right-panel"]) .app-header-tint [data-test-id="header-shell-slot"] {
+            width: auto !important;
+            min-width: 0 !important;
+            max-width: min(34vw, 132px) !important;
+            flex: 0 1 auto !important;
+            overflow: hidden !important;
+          }
+
+          html:has(.app-shell-left-panel) .app-header-tint [data-test-id="app-shell-header-context-menu-surface"],
+          html:has([data-app-shell-focus-area="right-panel"]) .app-header-tint [data-test-id="app-shell-header-context-menu-surface"] {
+            min-width: 0 !important;
+            flex: 1 1 auto !important;
+            overflow-x: auto !important;
+            overflow-y: hidden !important;
+            -webkit-overflow-scrolling: touch;
+            scrollbar-width: none;
+          }
+
+          html:has(.app-shell-left-panel) .app-header-tint [data-test-id="app-shell-header-context-menu-surface"]::-webkit-scrollbar,
+          html:has([data-app-shell-focus-area="right-panel"]) .app-header-tint [data-test-id="app-shell-header-context-menu-surface"]::-webkit-scrollbar {
+            display: none;
+          }
         }
 
         input,
@@ -155,198 +236,94 @@
         [contenteditable="true"],
         .ProseMirror {
           font-size: max(16px, 1em) !important;
-          scroll-margin-top: calc(var(--codex-visual-viewport-offset-top, 0px) + env(safe-area-inset-top) + 16px);
-          scroll-margin-bottom: calc(var(--codex-keyboard-inset-bottom, 0px) + env(safe-area-inset-bottom) + 112px);
         }
 
-        [data-codex-mobile-scroll-inset="true"] {
-          scroll-padding-top: calc(var(--codex-visual-viewport-offset-top, 0px) + env(safe-area-inset-top) + 12px) !important;
-          scroll-padding-bottom: calc(var(--codex-keyboard-inset-bottom, 0px) + env(safe-area-inset-bottom) + 112px) !important;
+        [data-radix-popper-content-wrapper],
+        [data-radix-popper-content-wrapper] > *,
+        [role="dialog"][data-state="open"] {
+          max-width: calc(var(--codex-layout-viewport-width, 100vw) - 16px) !important;
+          max-height: calc(var(--codex-layout-viewport-height, 100dvh) - 16px) !important;
         }
 
-        html:not(.codex-mobile-keyboard-open) [data-codex-mobile-scroll-inset="true"] {
-          scroll-padding-bottom: 12px !important;
+        [role="tooltip"] {
+          display: none !important;
         }
       }
     `;
     (document.head || document.documentElement).appendChild(style);
 
-    let maxObservedViewportHeight = 0;
-    let mobileScrollSnapshot = null;
-    let viewportUpdateScheduled = false;
+    let scheduled = false;
+    let lastViewportKey = "";
+    let lastViewportSizeKey = "";
+    let syntheticResizeTimer = null;
 
-    const viewportMetrics = () => {
-      const viewport = w.visualViewport;
-      const height = Math.max(0, Math.floor(viewport?.height || w.innerHeight || document.documentElement.clientHeight || 0));
-      const offsetTop = Math.max(0, Math.floor(viewport?.offsetTop || 0));
-      const layoutHeight = Math.max(0, Math.floor(w.innerHeight || document.documentElement.clientHeight || height));
-      maxObservedViewportHeight = Math.max(maxObservedViewportHeight, height);
-      const keyboardInset = Math.max(0, layoutHeight - height - offsetTop, maxObservedViewportHeight - height - offsetTop);
-      return { height, offsetTop, layoutHeight, keyboardInset };
-    };
-
-    const setViewportVars = (metrics = viewportMetrics()) => {
+    const viewportSize = () => {
       const root = document.documentElement;
-      if (metrics.height > 0) root.style.setProperty("--codex-visual-viewport-height", `${metrics.height}px`);
-      if (metrics.layoutHeight > 0) root.style.setProperty("--codex-layout-viewport-height", `${metrics.layoutHeight}px`);
-      root.style.setProperty("--codex-visual-viewport-offset-top", `${metrics.offsetTop}px`);
-      root.style.setProperty("--codex-keyboard-inset-bottom", `${metrics.keyboardInset}px`);
-    };
-
-    const scrollableAncestor = (element) => {
-      for (let node = element?.parentElement; node && node !== document.body; node = node.parentElement) {
-        const style = w.getComputedStyle ? w.getComputedStyle(node) : null;
-        const overflowY = String(style?.overflowY || "");
-        if (/(auto|scroll|overlay)/.test(overflowY) && node.scrollHeight > node.clientHeight + 1) return node;
-      }
-      return document.scrollingElement || document.documentElement;
-    };
-
-    const clearMobileScrollInset = () => {
-      document.querySelectorAll("[data-codex-mobile-scroll-inset='true']").forEach((element) => {
-        element.removeAttribute("data-codex-mobile-scroll-inset");
-      });
-    };
-
-    const rememberMobileScrollPosition = (element) => {
-      if (!isLikelyMobileKeyboardDevice() || !isComposerEditableElement(element)) return;
-      const scroller = scrollableAncestor(element);
-      mobileScrollSnapshot = {
-        createdAt: Date.now(),
-        scroller,
-        scrollerTop: scroller ? scroller.scrollTop : 0,
-        windowX: w.scrollX || 0,
-        windowY: w.scrollY || 0,
-      };
-      if (scroller) scroller.setAttribute("data-codex-mobile-scroll-inset", "true");
-    };
-
-    const restoreMobileScrollPosition = () => {
-      if (!mobileScrollSnapshot) return;
-      const snapshot = mobileScrollSnapshot;
-      mobileScrollSnapshot = null;
-      clearMobileScrollInset();
-      const restore = () => {
-        try {
-          if (snapshot.scroller?.isConnected) snapshot.scroller.scrollTop = snapshot.scrollerTop;
-          w.scrollTo(snapshot.windowX, snapshot.windowY);
-        } catch {}
-      };
-      if (typeof w.requestAnimationFrame === "function") {
-        w.requestAnimationFrame(() => w.setTimeout(restore, 0));
-      } else {
-        w.setTimeout(restore, 0);
-      }
-    };
-
-    const activeComposerElement = () => {
-      const active = document.activeElement;
-      return isComposerEditableElement(active) ? active : null;
-    };
-
-    const isKeyboardLikelyOpen = (metrics) => {
-      if (!isLikelyMobileKeyboardDevice()) return false;
-      if (!activeComposerElement()) return false;
-      return metrics.keyboardInset > 80 || (maxObservedViewportHeight > 0 && metrics.height < maxObservedViewportHeight * 0.78);
-    };
-
-    const keepActiveInputVisible = (metrics) => {
-      const active = activeComposerElement();
-      if (!active) return;
       const viewport = w.visualViewport;
-      const visibleTop = Math.max(0, viewport?.offsetTop || metrics.offsetTop || 0);
-      const visibleBottom = visibleTop + Math.max(0, viewport?.height || metrics.height || w.innerHeight || 0);
-      if (visibleBottom <= visibleTop) return;
+      const left = Math.max(0, Math.floor(viewport?.offsetLeft || 0));
+      const top = Math.max(0, Math.floor(viewport?.offsetTop || 0));
+      const width = Math.max(
+        1,
+        Math.floor(viewport?.width || root.clientWidth || w.innerWidth || 0)
+      );
+      const height = Math.max(
+        1,
+        Math.floor(viewport?.height || root.clientHeight || w.innerHeight || 0)
+      );
+      return { left, top, width, height };
+    };
 
-      const scroller = scrollableAncestor(active);
-      if (scroller) scroller.setAttribute("data-codex-mobile-scroll-inset", "true");
+    const dispatchSyntheticResize = () => {
+      if (syntheticResizeTimer) w.clearTimeout(syntheticResizeTimer);
+      syntheticResizeTimer = w.setTimeout(() => {
+        syntheticResizeTimer = null;
+        try {
+          w.dispatchEvent(new Event("resize"));
+        } catch {}
+      }, 0);
+    };
 
-      const rect = active.getBoundingClientRect();
-      const bottomLimit = visibleBottom - Math.min(112, Math.max(36, metrics.keyboardInset + 24));
-      const topLimit = visibleTop + 12;
-      let delta = 0;
-      if (rect.bottom > bottomLimit) {
-        delta = rect.bottom - bottomLimit;
-      } else if (rect.top < topLimit) {
-        delta = rect.top - topLimit;
+    const updateViewportVars = () => {
+      scheduled = false;
+      if (!isLikelyMobileKeyboardDevice()) return;
+      const { left, top, width, height } = viewportSize();
+      const key = `${left},${top}:${width}x${height}`;
+      if (key === lastViewportKey) return;
+      lastViewportKey = key;
+      const root = document.documentElement;
+      root.style.setProperty("--codex-layout-viewport-left", `${left}px`);
+      root.style.setProperty("--codex-layout-viewport-top", `${top}px`);
+      root.style.setProperty("--codex-layout-viewport-width", `${width}px`);
+      root.style.setProperty("--codex-layout-viewport-height", `${height}px`);
+      root.classList.add("codex-mobile-viewport-adapter");
+      const sizeKey = `${width}x${height}`;
+      if (sizeKey !== lastViewportSizeKey) {
+        lastViewportSizeKey = sizeKey;
+        dispatchSyntheticResize();
       }
-      if (Math.abs(delta) < 1) return;
-
-      if (scroller && scroller !== document.documentElement && scroller !== document.body) {
-        scroller.scrollTop += delta;
-        return;
-      }
-      try {
-        w.scrollBy(0, delta);
-      } catch {}
     };
 
     const scheduleViewportUpdate = () => {
-      if (viewportUpdateScheduled) return;
-      viewportUpdateScheduled = true;
-      const run = () => {
-        viewportUpdateScheduled = false;
-        const metrics = viewportMetrics();
-        setViewportVars(metrics);
-        const keyboardOpen = isKeyboardLikelyOpen(metrics);
-        document.documentElement.classList.toggle("codex-mobile-keyboard-open", keyboardOpen);
-        if (keyboardOpen) {
-          keepActiveInputVisible(metrics);
-        } else if (!activeComposerElement()) {
-          restoreMobileScrollPosition();
-        }
-      };
+      if (scheduled) return;
+      scheduled = true;
       if (typeof w.requestAnimationFrame === "function") {
-        w.requestAnimationFrame(run);
+        w.requestAnimationFrame(updateViewportVars);
       } else {
-        w.setTimeout(run, 0);
+        w.setTimeout(updateViewportVars, 0);
       }
-      w.setTimeout(run, 80);
-      w.setTimeout(run, 240);
     };
 
-    const handleFocusIn = (event) => {
-      if (isComposerEditableElement(event.target)) rememberMobileScrollPosition(event.target);
-      scheduleViewportUpdate();
-    };
-
-    const handleFocusOut = () => {
-      w.setTimeout(() => {
-        if (!activeComposerElement()) {
-          document.documentElement.classList.remove("codex-mobile-keyboard-open");
-          restoreMobileScrollPosition();
-        }
-      }, 180);
-    };
-
-    const preventZoomGesture = (event) => {
-      if (!isLikelyMobileKeyboardDevice()) return;
-      if (event.touches && event.touches.length < 2) return;
-      event.preventDefault();
-    };
-
-    setViewportVars();
+    scheduleViewportUpdate();
     w.addEventListener("resize", scheduleViewportUpdate, { passive: true });
-    w.addEventListener(
-      "orientationchange",
-      () => {
-        maxObservedViewportHeight = 0;
-        restoreMobileScrollPosition();
-        scheduleViewportUpdate();
-      },
-      { passive: true }
-    );
+    w.addEventListener("orientationchange", scheduleViewportUpdate, { passive: true });
+    w.addEventListener("pageshow", scheduleViewportUpdate, { passive: true });
     w.visualViewport?.addEventListener("resize", scheduleViewportUpdate, { passive: true });
     w.visualViewport?.addEventListener("scroll", scheduleViewportUpdate, { passive: true });
-    document.addEventListener("focusin", handleFocusIn, true);
-    document.addEventListener("focusout", handleFocusOut, true);
-    document.addEventListener("input", scheduleViewportUpdate, true);
-    document.addEventListener("touchmove", preventZoomGesture, { passive: false });
-    document.addEventListener("gesturestart", preventZoomGesture, { passive: false });
-    document.addEventListener("gesturechange", preventZoomGesture, { passive: false });
+    document.addEventListener("focusin", scheduleViewportUpdate, true);
+    document.addEventListener("focusout", scheduleViewportUpdate, true);
   }
 
-  installMobileViewportGuards();
+  installMobileViewportAdapter();
 
   /**
    * Electron 的 <webview> 在浏览器里不存在。
@@ -492,8 +469,9 @@
   const listeners = new Map();
   const authStatusCallbacks = new Set();
   const terminalMessageQueues = new Map();
-  const MOBILE_COMPOSER_POST_SEND_FOCUS_BLOCK_MS = 4000;
+  const MOBILE_COMPOSER_POST_SEND_FOCUS_BLOCK_MS = 6500;
   const MOBILE_COMPOSER_MANUAL_FOCUS_MS = 900;
+  const MOBILE_COMPOSER_BLUR_DELAYS_MS = [0, 50, 160, 360, 700];
   const MOBILE_SIDEBAR_AUTO_COLLAPSE_DELAY_MS = 80;
   const STATSIG_DEFAULT_FEATURES_CONFIG = "statsig_default_enable_features";
   const STATSIG_I18N_LAYER_CONFIG = "72216192";
@@ -551,6 +529,68 @@
     );
   }
 
+  function activeComposerEditableElement() {
+    const active = document.activeElement;
+    return isComposerEditableElement(active) ? active : null;
+  }
+
+  function elementDebugSummary(element) {
+    if (!element || element.nodeType !== 1) return null;
+    const rect =
+      typeof element.getBoundingClientRect === "function"
+        ? element.getBoundingClientRect()
+        : null;
+    return {
+      tag: String(element.tagName || "").toLowerCase(),
+      id: element.id || "",
+      className: String(element.className || ""),
+      role: element.getAttribute?.("role") || "",
+      ariaLabel: element.getAttribute?.("aria-label") || "",
+      ariaHasPopup: element.getAttribute?.("aria-haspopup") || "",
+      ariaExpanded: element.getAttribute?.("aria-expanded") || "",
+      dataState: element.getAttribute?.("data-state") || "",
+      text: String(element.textContent || "").trim().slice(0, 80),
+      rect: rect
+        ? {
+            x: Math.round(rect.x),
+            y: Math.round(rect.y),
+            width: Math.round(rect.width),
+            height: Math.round(rect.height),
+          }
+        : null,
+    };
+  }
+
+  function blurActiveMobileComposer() {
+    if (!opencodexSettingEnabled("mobileKeyboardOptimization")) return;
+    if (!isLikelyMobileKeyboardDevice()) return;
+    const blur = () => {
+      const active = activeComposerEditableElement();
+      if (!active || typeof active.blur !== "function") return;
+      try {
+        active.blur();
+      } catch {}
+    };
+    for (const delay of MOBILE_COMPOSER_BLUR_DELAYS_MS) {
+      if (delay === 0 && typeof w.requestAnimationFrame === "function") {
+        w.requestAnimationFrame(blur);
+      } else {
+        w.setTimeout(blur, delay);
+      }
+    }
+  }
+
+  function markMobileComposerSubmitIntent() {
+    if (!opencodexSettingEnabled("mobileKeyboardOptimization")) return;
+    if (!isLikelyMobileKeyboardDevice()) return;
+    mobileComposerFocusBlockedUntilMs = Date.now() + MOBILE_COMPOSER_POST_SEND_FOCUS_BLOCK_MS;
+    debugMobileComposer("submit intent detected; blurring composer", {
+      blockedUntilMs: mobileComposerFocusBlockedUntilMs,
+      active: elementDebugSummary(activeComposerEditableElement()),
+    });
+    blurActiveMobileComposer();
+  }
+
   /** 用户主动点输入区时，发送后的 focus guard 必须放行。 */
   function rememberManualComposerFocusIntent(event) {
     const target = event && event.target;
@@ -565,6 +605,13 @@
     if (channel === "turn:start" || channel === "start-conversation") return true;
     if (channel !== "codex_desktop:message-from-view") return false;
     if (!payload || typeof payload !== "object") return false;
+    if (
+      payload.type === "thread-queued-followups-changed" &&
+      Array.isArray(payload.messages) &&
+      payload.messages.length > 0
+    ) {
+      return true;
+    }
     const request = payload.request && typeof payload.request === "object" ? payload.request : null;
     return !!request && request.method === "turn/start";
   }
@@ -573,7 +620,7 @@
   function markMobileComposerPromptSent(channel, payload) {
     if (!opencodexSettingEnabled("mobileKeyboardOptimization")) return;
     if (!isLikelyMobileKeyboardDevice() || !isPromptSendInvoke(channel, payload)) return;
-    mobileComposerFocusBlockedUntilMs = Date.now() + MOBILE_COMPOSER_POST_SEND_FOCUS_BLOCK_MS;
+    markMobileComposerSubmitIntent();
   }
 
   /** 只拦发送后的程序化 composer focus，不拦用户手动点击输入区。 */
@@ -927,18 +974,23 @@
     } catch {}
   }
 
+  function toggleLeftSidebar() {
+    const toggleButton = findSidebarToggleButton();
+    if (toggleButton && typeof toggleButton.click === "function") {
+      toggleButton.click();
+      return true;
+    }
+    postSidebarToggleMessage();
+    return true;
+  }
+
   function collapseMobileSidebarAfterSelection() {
     if (mobileSidebarCollapseTimer) w.clearTimeout(mobileSidebarCollapseTimer);
     mobileSidebarCollapseTimer = w.setTimeout(() => {
       mobileSidebarCollapseTimer = null;
       const panel = sidebarPanelElement();
       if (!panel || !visibleElement(panel)) return;
-      const toggleButton = findSidebarToggleButton();
-      if (toggleButton && typeof toggleButton.click === "function") {
-        toggleButton.click();
-        return;
-      }
-      postSidebarToggleMessage();
+      toggleLeftSidebar();
     }, MOBILE_SIDEBAR_AUTO_COLLAPSE_DELAY_MS);
   }
 
@@ -988,7 +1040,7 @@
   function installMobileSidebarAutoCollapse() {
     if (!document || document.__codexMobileSidebarAutoCollapseInstalled) return;
     document.__codexMobileSidebarAutoCollapseInstalled = true;
-    document.addEventListener("click", handleMobileSidebarAutoCollapseClick, true);
+    document.addEventListener("click", handleMobileSidebarAutoCollapseClick);
   }
 
   installMobileSidebarAutoCollapse();

--- a/web-shell/codex-bridge-polyfill.js
+++ b/web-shell/codex-bridge-polyfill.js
@@ -136,19 +136,18 @@
     style.id = "codex-mobile-viewport-guards";
     style.textContent = `
       @media (max-width: 820px), (pointer: coarse) {
-        html,
-        body,
-        #root {
-          height: var(--codex-visual-viewport-height, 100dvh) !important;
-          min-height: var(--codex-visual-viewport-height, 100dvh) !important;
-          max-height: var(--codex-visual-viewport-height, 100dvh) !important;
-          overflow: hidden;
+        html {
+          scroll-padding-top: calc(var(--codex-visual-viewport-offset-top, 0px) + env(safe-area-inset-top) + 12px);
+          scroll-padding-bottom: calc(var(--codex-keyboard-inset-bottom, 0px) + env(safe-area-inset-bottom) + 112px);
+          -webkit-text-size-adjust: 100%;
+          text-size-adjust: 100%;
         }
 
         body {
           width: 100%;
+          min-height: 100dvh;
           touch-action: pan-x pan-y;
-          overscroll-behavior: none;
+          overscroll-behavior-y: contain;
         }
 
         input,
@@ -156,45 +155,115 @@
         [contenteditable="true"],
         .ProseMirror {
           font-size: max(16px, 1em) !important;
-          scroll-margin-bottom: calc(var(--codex-keyboard-inset-bottom, 0px) + 96px);
+          scroll-margin-top: calc(var(--codex-visual-viewport-offset-top, 0px) + env(safe-area-inset-top) + 16px);
+          scroll-margin-bottom: calc(var(--codex-keyboard-inset-bottom, 0px) + env(safe-area-inset-bottom) + 112px);
+        }
+
+        [data-codex-mobile-scroll-inset="true"] {
+          scroll-padding-top: calc(var(--codex-visual-viewport-offset-top, 0px) + env(safe-area-inset-top) + 12px) !important;
+          scroll-padding-bottom: calc(var(--codex-keyboard-inset-bottom, 0px) + env(safe-area-inset-bottom) + 112px) !important;
+        }
+
+        html:not(.codex-mobile-keyboard-open) [data-codex-mobile-scroll-inset="true"] {
+          scroll-padding-bottom: 12px !important;
         }
       }
     `;
     (document.head || document.documentElement).appendChild(style);
 
-    const setViewportVars = () => {
+    let maxObservedViewportHeight = 0;
+    let mobileScrollSnapshot = null;
+    let viewportUpdateScheduled = false;
+
+    const viewportMetrics = () => {
       const viewport = w.visualViewport;
       const height = Math.max(0, Math.floor(viewport?.height || w.innerHeight || document.documentElement.clientHeight || 0));
       const offsetTop = Math.max(0, Math.floor(viewport?.offsetTop || 0));
       const layoutHeight = Math.max(0, Math.floor(w.innerHeight || document.documentElement.clientHeight || height));
-      const keyboardInset = Math.max(0, layoutHeight - height - offsetTop);
+      maxObservedViewportHeight = Math.max(maxObservedViewportHeight, height);
+      const keyboardInset = Math.max(0, layoutHeight - height - offsetTop, maxObservedViewportHeight - height - offsetTop);
+      return { height, offsetTop, layoutHeight, keyboardInset };
+    };
+
+    const setViewportVars = (metrics = viewportMetrics()) => {
       const root = document.documentElement;
-      if (height > 0) root.style.setProperty("--codex-visual-viewport-height", `${height}px`);
-      root.style.setProperty("--codex-visual-viewport-offset-top", `${offsetTop}px`);
-      root.style.setProperty("--codex-keyboard-inset-bottom", `${keyboardInset}px`);
+      if (metrics.height > 0) root.style.setProperty("--codex-visual-viewport-height", `${metrics.height}px`);
+      if (metrics.layoutHeight > 0) root.style.setProperty("--codex-layout-viewport-height", `${metrics.layoutHeight}px`);
+      root.style.setProperty("--codex-visual-viewport-offset-top", `${metrics.offsetTop}px`);
+      root.style.setProperty("--codex-keyboard-inset-bottom", `${metrics.keyboardInset}px`);
     };
 
     const scrollableAncestor = (element) => {
       for (let node = element?.parentElement; node && node !== document.body; node = node.parentElement) {
         const style = w.getComputedStyle ? w.getComputedStyle(node) : null;
         const overflowY = String(style?.overflowY || "");
-        if (/(auto|scroll)/.test(overflowY) && node.scrollHeight > node.clientHeight) return node;
+        if (/(auto|scroll|overlay)/.test(overflowY) && node.scrollHeight > node.clientHeight + 1) return node;
       }
-      return null;
+      return document.scrollingElement || document.documentElement;
     };
 
-    const keepActiveInputVisible = () => {
-      if (!isLikelyMobileKeyboardDevice()) return;
+    const clearMobileScrollInset = () => {
+      document.querySelectorAll("[data-codex-mobile-scroll-inset='true']").forEach((element) => {
+        element.removeAttribute("data-codex-mobile-scroll-inset");
+      });
+    };
+
+    const rememberMobileScrollPosition = (element) => {
+      if (!isLikelyMobileKeyboardDevice() || !isComposerEditableElement(element)) return;
+      const scroller = scrollableAncestor(element);
+      mobileScrollSnapshot = {
+        createdAt: Date.now(),
+        scroller,
+        scrollerTop: scroller ? scroller.scrollTop : 0,
+        windowX: w.scrollX || 0,
+        windowY: w.scrollY || 0,
+      };
+      if (scroller) scroller.setAttribute("data-codex-mobile-scroll-inset", "true");
+    };
+
+    const restoreMobileScrollPosition = () => {
+      if (!mobileScrollSnapshot) return;
+      const snapshot = mobileScrollSnapshot;
+      mobileScrollSnapshot = null;
+      clearMobileScrollInset();
+      const restore = () => {
+        try {
+          if (snapshot.scroller?.isConnected) snapshot.scroller.scrollTop = snapshot.scrollerTop;
+          w.scrollTo(snapshot.windowX, snapshot.windowY);
+        } catch {}
+      };
+      if (typeof w.requestAnimationFrame === "function") {
+        w.requestAnimationFrame(() => w.setTimeout(restore, 0));
+      } else {
+        w.setTimeout(restore, 0);
+      }
+    };
+
+    const activeComposerElement = () => {
       const active = document.activeElement;
-      if (!isComposerEditableElement(active)) return;
+      return isComposerEditableElement(active) ? active : null;
+    };
+
+    const isKeyboardLikelyOpen = (metrics) => {
+      if (!isLikelyMobileKeyboardDevice()) return false;
+      if (!activeComposerElement()) return false;
+      return metrics.keyboardInset > 80 || (maxObservedViewportHeight > 0 && metrics.height < maxObservedViewportHeight * 0.78);
+    };
+
+    const keepActiveInputVisible = (metrics) => {
+      const active = activeComposerElement();
+      if (!active) return;
       const viewport = w.visualViewport;
-      const visibleTop = Math.max(0, viewport?.offsetTop || 0);
-      const visibleBottom = visibleTop + Math.max(0, viewport?.height || w.innerHeight || 0);
+      const visibleTop = Math.max(0, viewport?.offsetTop || metrics.offsetTop || 0);
+      const visibleBottom = visibleTop + Math.max(0, viewport?.height || metrics.height || w.innerHeight || 0);
       if (visibleBottom <= visibleTop) return;
 
+      const scroller = scrollableAncestor(active);
+      if (scroller) scroller.setAttribute("data-codex-mobile-scroll-inset", "true");
+
       const rect = active.getBoundingClientRect();
-      const bottomLimit = visibleBottom - 18;
-      const topLimit = visibleTop + 8;
+      const bottomLimit = visibleBottom - Math.min(112, Math.max(36, metrics.keyboardInset + 24));
+      const topLimit = visibleTop + 12;
       let delta = 0;
       if (rect.bottom > bottomLimit) {
         delta = rect.bottom - bottomLimit;
@@ -203,8 +272,7 @@
       }
       if (Math.abs(delta) < 1) return;
 
-      const scroller = scrollableAncestor(active);
-      if (scroller) {
+      if (scroller && scroller !== document.documentElement && scroller !== document.body) {
         scroller.scrollTop += delta;
         return;
       }
@@ -214,10 +282,19 @@
     };
 
     const scheduleViewportUpdate = () => {
-      setViewportVars();
+      if (viewportUpdateScheduled) return;
+      viewportUpdateScheduled = true;
       const run = () => {
-        setViewportVars();
-        keepActiveInputVisible();
+        viewportUpdateScheduled = false;
+        const metrics = viewportMetrics();
+        setViewportVars(metrics);
+        const keyboardOpen = isKeyboardLikelyOpen(metrics);
+        document.documentElement.classList.toggle("codex-mobile-keyboard-open", keyboardOpen);
+        if (keyboardOpen) {
+          keepActiveInputVisible(metrics);
+        } else if (!activeComposerElement()) {
+          restoreMobileScrollPosition();
+        }
       };
       if (typeof w.requestAnimationFrame === "function") {
         w.requestAnimationFrame(run);
@@ -227,6 +304,21 @@
       w.setTimeout(run, 80);
       w.setTimeout(run, 240);
     };
+
+    const handleFocusIn = (event) => {
+      if (isComposerEditableElement(event.target)) rememberMobileScrollPosition(event.target);
+      scheduleViewportUpdate();
+    };
+
+    const handleFocusOut = () => {
+      w.setTimeout(() => {
+        if (!activeComposerElement()) {
+          document.documentElement.classList.remove("codex-mobile-keyboard-open");
+          restoreMobileScrollPosition();
+        }
+      }, 180);
+    };
+
     const preventZoomGesture = (event) => {
       if (!isLikelyMobileKeyboardDevice()) return;
       if (event.touches && event.touches.length < 2) return;
@@ -235,10 +327,19 @@
 
     setViewportVars();
     w.addEventListener("resize", scheduleViewportUpdate, { passive: true });
-    w.addEventListener("orientationchange", scheduleViewportUpdate, { passive: true });
+    w.addEventListener(
+      "orientationchange",
+      () => {
+        maxObservedViewportHeight = 0;
+        restoreMobileScrollPosition();
+        scheduleViewportUpdate();
+      },
+      { passive: true }
+    );
     w.visualViewport?.addEventListener("resize", scheduleViewportUpdate, { passive: true });
     w.visualViewport?.addEventListener("scroll", scheduleViewportUpdate, { passive: true });
-    document.addEventListener("focusin", scheduleViewportUpdate, true);
+    document.addEventListener("focusin", handleFocusIn, true);
+    document.addEventListener("focusout", handleFocusOut, true);
     document.addEventListener("input", scheduleViewportUpdate, true);
     document.addEventListener("touchmove", preventZoomGesture, { passive: false });
     document.addEventListener("gesturestart", preventZoomGesture, { passive: false });

--- a/web-shell/codex-bridge-polyfill.js
+++ b/web-shell/codex-bridge-polyfill.js
@@ -199,11 +199,144 @@
           overflow: hidden !important;
         }
 
+        #codex-mobile-sidebar-button,
+        #codex-mobile-panel-controls,
+        #codex-mobile-sidebar-backdrop {
+          display: block !important;
+        }
+
+        #codex-mobile-sidebar-button {
+          position: fixed !important;
+          top: max(10px, env(safe-area-inset-top)) !important;
+          left: 50% !important;
+          transform: translateX(-50%) !important;
+          z-index: 2147483001 !important;
+          min-width: 72px !important;
+          height: 40px !important;
+          padding: 0 14px !important;
+          border: 1px solid rgb(226 232 240 / 0.92) !important;
+          border-radius: 999px !important;
+          background: rgb(255 255 255 / 0.92) !important;
+          color: rgb(31 41 55) !important;
+          box-shadow: 0 10px 28px rgb(15 23 42 / 0.12) !important;
+          -webkit-backdrop-filter: blur(14px) !important;
+          backdrop-filter: blur(14px) !important;
+          font: 600 14px/1 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif !important;
+          letter-spacing: 0 !important;
+          touch-action: manipulation !important;
+        }
+
+        #codex-mobile-panel-controls {
+          position: fixed !important;
+          top: max(10px, env(safe-area-inset-top)) !important;
+          right: max(10px, env(safe-area-inset-right)) !important;
+          z-index: 2147483001 !important;
+          display: flex !important;
+          align-items: center !important;
+          gap: 6px !important;
+        }
+
+        #codex-mobile-panel-controls button {
+          width: 38px !important;
+          height: 38px !important;
+          padding: 0 !important;
+          border: 1px solid rgb(226 232 240 / 0.92) !important;
+          border-radius: 999px !important;
+          background: rgb(255 255 255 / 0.92) !important;
+          color: rgb(31 41 55) !important;
+          box-shadow: 0 10px 28px rgb(15 23 42 / 0.12) !important;
+          -webkit-backdrop-filter: blur(14px) !important;
+          backdrop-filter: blur(14px) !important;
+          font: 700 13px/1 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif !important;
+          letter-spacing: 0 !important;
+          touch-action: manipulation !important;
+        }
+
+        html.codex-mobile-sidebar-open #codex-mobile-sidebar-button {
+          background: rgb(17 24 39 / 0.92) !important;
+          border-color: rgb(17 24 39 / 0.1) !important;
+          color: white !important;
+        }
+
+        #codex-mobile-sidebar-backdrop {
+          position: fixed !important;
+          inset: 0 !important;
+          z-index: 2147482999 !important;
+          background: rgb(15 23 42 / 0.28) !important;
+          opacity: 0 !important;
+          pointer-events: none !important;
+          transition: opacity 160ms ease !important;
+        }
+
+        html.codex-mobile-sidebar-open #codex-mobile-sidebar-backdrop {
+          opacity: 1 !important;
+          pointer-events: auto !important;
+        }
+
+        .app-shell-left-panel,
+        .codex-mobile-sidebar-panel {
+          position: fixed !important;
+          top: 0 !important;
+          bottom: 0 !important;
+          left: 0 !important;
+          width: min(86vw, 340px) !important;
+          min-width: 0 !important;
+          max-width: min(86vw, 340px) !important;
+          height: var(--codex-layout-viewport-height, 100dvh) !important;
+          max-height: var(--codex-layout-viewport-height, 100dvh) !important;
+          padding-top: max(58px, calc(env(safe-area-inset-top) + 50px)) !important;
+          z-index: 2147483000 !important;
+          background: rgb(255 255 255 / 0.98) !important;
+          box-shadow: 18px 0 42px rgb(15 23 42 / 0.16) !important;
+          transform: translate3d(-104%, 0, 0) !important;
+          transition: transform 180ms ease !important;
+          overflow: hidden !important;
+          pointer-events: none !important;
+          -webkit-backdrop-filter: blur(18px) !important;
+          backdrop-filter: blur(18px) !important;
+        }
+
+        html.codex-mobile-sidebar-open .app-shell-left-panel,
+        html.codex-mobile-sidebar-open .codex-mobile-sidebar-panel {
+          transform: translate3d(0, 0, 0) !important;
+          pointer-events: auto !important;
+        }
+
+        .app-shell-left-panel nav,
+        .app-shell-left-panel [data-app-action-sidebar-scroll],
+        .codex-mobile-sidebar-panel nav,
+        .codex-mobile-sidebar-panel [data-app-action-sidebar-scroll] {
+          max-width: 100% !important;
+          height: 100% !important;
+          overflow-x: hidden !important;
+          overflow-y: auto !important;
+          -webkit-overflow-scrolling: touch !important;
+        }
+
+        body > div:not(#codex-mobile-sidebar-backdrop):not(#codex-mobile-sidebar-button):not(#codex-mobile-panel-controls),
+        #root > * {
+          max-width: 100vw !important;
+        }
+
+        [data-app-shell-focus-area],
+        [data-app-shell-focus-area="right-panel"],
+        main {
+          left: 0 !important;
+          margin-left: 0 !important;
+          min-width: 0 !important;
+          width: 100vw !important;
+          max-width: 100vw !important;
+        }
+
+        html.codex-mobile-sidebar-open {
+          touch-action: none;
+        }
+
         @supports selector(:has(*)) {
           html:has(.app-shell-left-panel) .app-header-tint,
           html:has([data-app-shell-focus-area="right-panel"]) .app-header-tint {
             min-width: 0 !important;
-            overflow: hidden !important;
+            overflow: visible !important;
           }
 
           html:has(.app-shell-left-panel) .app-header-tint [data-test-id="header-shell-slot"],
@@ -212,7 +345,7 @@
             min-width: 0 !important;
             max-width: min(34vw, 132px) !important;
             flex: 0 1 auto !important;
-            overflow: hidden !important;
+            overflow: visible !important;
           }
 
           html:has(.app-shell-left-panel) .app-header-tint [data-test-id="app-shell-header-context-menu-surface"],
@@ -247,6 +380,35 @@
 
         [role="tooltip"] {
           display: none !important;
+        }
+
+        [role="menubar"],
+        [aria-label="Application menu"],
+        [data-testid*="menu-bar"],
+        [data-test-id*="menu-bar"],
+        .codex-mobile-hidden-desktop-chrome {
+          display: none !important;
+          pointer-events: none !important;
+        }
+
+        header,
+        [data-test-id="app-shell-header"],
+        [data-testid="app-shell-header"] {
+          min-width: 0 !important;
+          max-width: 100vw !important;
+          overflow: visible !important;
+        }
+
+        main,
+        [data-app-shell-focus-area],
+        [data-testid*="composer"],
+        [data-test-id*="composer"] {
+          max-width: 100vw !important;
+        }
+
+        form:has(.ProseMirror),
+        div:has(> .ProseMirror) {
+          max-width: calc(100vw - 18px) !important;
         }
       }
     `;
@@ -650,6 +812,346 @@
 
   installMobileComposerFocusGuard();
 
+  const DESKTOP_MENU_LABELS = new Set([
+    "文件",
+    "编辑",
+    "查看",
+    "窗口",
+    "帮助",
+    "File",
+    "Edit",
+    "View",
+    "Window",
+    "Help",
+  ]);
+
+  function mobileChromeElementVisible(element) {
+    if (!element || typeof element.getBoundingClientRect !== "function") return false;
+    const rect = element.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return false;
+    const style = w.getComputedStyle ? w.getComputedStyle(element) : null;
+    return !style || (style.display !== "none" && style.visibility !== "hidden" && Number(style.opacity || 1) !== 0);
+  }
+
+  function desktopMenuLabel(element) {
+    if (!element) return "";
+    return String(
+      element.getAttribute?.("aria-label") ||
+        element.getAttribute?.("title") ||
+        element.innerText ||
+        element.textContent ||
+        ""
+    )
+      .replace(/\s+/g, "")
+      .trim();
+  }
+
+  function desktopMenuScore(container) {
+    if (!container || typeof container.querySelectorAll !== "function") return 0;
+    const labels = new Set();
+    const candidates = container.querySelectorAll(
+      'button,[role="menuitem"],[role="menuitemradio"],[role="menuitemcheckbox"],[aria-haspopup="menu"]'
+    );
+    for (const candidate of candidates) {
+      const label = desktopMenuLabel(candidate);
+      if (DESKTOP_MENU_LABELS.has(label) && mobileChromeElementVisible(candidate)) labels.add(label);
+      if (labels.size >= 3) return labels.size;
+    }
+    return labels.size;
+  }
+
+  function desktopMenuChromeContainer(element) {
+    let best = null;
+    for (let node = element; node && node !== document.body; node = node.parentElement) {
+      if (node.classList?.contains("codex-mobile-hidden-desktop-chrome")) return null;
+      if (!mobileChromeElementVisible(node)) continue;
+      const rect = node.getBoundingClientRect();
+      if (rect.top > 150 || rect.height > 132 || rect.width < 160) continue;
+      if (desktopMenuScore(node) >= 3) best = node;
+    }
+    return best;
+  }
+
+  function hideMobileDesktopChrome(root = document) {
+    if (!isLikelyMobileKeyboardDevice()) return;
+    const scope = root && root.nodeType === 1 ? root : document;
+    if (scope.nodeType === 1 && DESKTOP_MENU_LABELS.has(desktopMenuLabel(scope))) {
+      const container = desktopMenuChromeContainer(scope);
+      if (container) {
+        container.classList.add("codex-mobile-hidden-desktop-chrome");
+        container.setAttribute("aria-hidden", "true");
+      }
+    }
+    const candidates =
+      typeof scope.querySelectorAll === "function"
+        ? scope.querySelectorAll(
+            'button,[role="menuitem"],[role="menuitemradio"],[role="menuitemcheckbox"],[aria-haspopup="menu"]'
+          )
+        : [];
+    for (const candidate of candidates) {
+      if (!DESKTOP_MENU_LABELS.has(desktopMenuLabel(candidate))) continue;
+      const container = desktopMenuChromeContainer(candidate);
+      if (!container) continue;
+      container.classList.add("codex-mobile-hidden-desktop-chrome");
+      container.setAttribute("aria-hidden", "true");
+    }
+  }
+
+  function installMobileDesktopChromeHider() {
+    if (!document || document.__codexMobileDesktopChromeHiderInstalled) return;
+    document.__codexMobileDesktopChromeHiderInstalled = true;
+    const scan = () => {
+      try {
+        hideMobileDesktopChrome(document);
+      } catch {}
+    };
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", scan, { once: true });
+    } else {
+      scan();
+    }
+    w.addEventListener("resize", scan, { passive: true });
+    w.addEventListener("orientationchange", scan, { passive: true });
+    const observer = new MutationObserver((mutations) => {
+      if (!isLikelyMobileKeyboardDevice()) return;
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes || []) {
+          hideMobileDesktopChrome(node);
+        }
+      }
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+  }
+
+  installMobileDesktopChromeHider();
+
+  function setMobileSidebarOpen(open) {
+    ensureMobileSidebarPanel();
+    document.documentElement.classList.toggle("codex-mobile-sidebar-open", !!open);
+    const button = document.getElementById("codex-mobile-sidebar-button");
+    if (button) {
+      button.setAttribute("aria-expanded", open ? "true" : "false");
+      button.textContent = open ? "关闭" : "会话";
+    }
+  }
+
+  function toggleMobileSidebar() {
+    const panel = ensureMobileSidebarPanel();
+    if (!panel) {
+      toggleLeftSidebar();
+      w.setTimeout(() => {
+        ensureMobileSidebarPanel();
+        setMobileSidebarOpen(true);
+      }, 160);
+      return;
+    }
+    setMobileSidebarOpen(!document.documentElement.classList.contains("codex-mobile-sidebar-open"));
+  }
+
+  function buttonLabel(button) {
+    return String(
+      button?.getAttribute?.("aria-label") ||
+        button?.getAttribute?.("title") ||
+        button?.innerText ||
+        button?.textContent ||
+        ""
+    )
+      .replace(/\s+/g, " ")
+      .trim()
+      .toLowerCase();
+  }
+
+  function isMobileOverlayButton(button) {
+    return !!button?.closest?.("#codex-mobile-sidebar-button,#codex-mobile-sidebar-backdrop,#codex-mobile-panel-controls");
+  }
+
+  function clickButton(button) {
+    if (!button || typeof button.click !== "function") return false;
+    try {
+      button.click();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  function officialPanelButtonByLabel(kind) {
+    const labelTerms =
+      kind === "side"
+        ? ["side panel", "right panel", "toggle side", "toggle right", "侧边", "右侧", "侧栏"]
+        : ["bottom panel", "toggle bottom", "terminal panel", "底部", "底栏", "终端"];
+    return Array.from(document.querySelectorAll("button")).find((button) => {
+      if (isMobileOverlayButton(button)) return false;
+      const label = buttonLabel(button);
+      return label && labelTerms.some((term) => label.includes(term));
+    });
+  }
+
+  function officialPanelButtonsByPosition() {
+    const viewportWidth = w.innerWidth || document.documentElement.clientWidth || 0;
+    return Array.from(document.querySelectorAll("button"))
+      .filter((button) => {
+        if (isMobileOverlayButton(button) || button.disabled || button.getAttribute("aria-disabled") === "true") return false;
+        if (button.closest(".codex-mobile-sidebar-panel,.app-shell-left-panel")) return false;
+        const label = buttonLabel(button);
+        if (label === "会话" || label === "地址" || label === "关闭") return false;
+        const rect = typeof button.getBoundingClientRect === "function" ? button.getBoundingClientRect() : null;
+        if (!rect || rect.width <= 0 || rect.height <= 0) return false;
+        if (rect.top > 120 || rect.bottom < 0) return false;
+        return rect.left > viewportWidth * 0.45 || rect.right > viewportWidth * 0.55;
+      })
+      .sort((a, b) => a.getBoundingClientRect().left - b.getBoundingClientRect().left);
+  }
+
+  function toggleOfficialPanel(kind) {
+    const labeled = officialPanelButtonByLabel(kind);
+    if (clickButton(labeled)) return true;
+    const positioned = officialPanelButtonsByPosition();
+    if (positioned.length === 0) return false;
+    const target =
+      kind === "side"
+        ? positioned[positioned.length - 1]
+        : positioned[Math.max(0, positioned.length - 2)];
+    return clickButton(target);
+  }
+
+  function sidebarCandidateText(element) {
+    return String(
+      element?.getAttribute?.("aria-label") ||
+        element?.getAttribute?.("title") ||
+        element?.innerText ||
+        element?.textContent ||
+        ""
+    )
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  function hasSidebarContent(element) {
+    if (!element || element.nodeType !== 1 || typeof element.querySelector !== "function") return false;
+    if (element.id === "codex-mobile-sidebar-button" || element.id === "codex-mobile-sidebar-backdrop") return false;
+    const rect = typeof element.getBoundingClientRect === "function" ? element.getBoundingClientRect() : null;
+    if (rect && (rect.width < 120 || rect.width > Math.min(w.innerWidth * 0.92, 380))) return false;
+    if (element.querySelector(SIDEBAR_THREAD_ROW_SELECTOR)) return true;
+    if (element.querySelector("[data-thread-title]")) return true;
+    if (element.querySelector(SIDEBAR_SCROLL_SELECTOR)) return true;
+    const text = sidebarCandidateText(element);
+    const labels = ["New chat", "Search", "Chats", "Projects", "Skills", "新建", "搜索", "会话", "项目"];
+    return labels.filter((label) => text.includes(label)).length >= 2;
+  }
+
+  function sidebarContainerFromNode(node) {
+    if (!node || node.nodeType !== 1) return null;
+    for (let current = node; current && current !== document.body; current = current.parentElement) {
+      if (current.id === "root" || current === document.documentElement) break;
+      if (!hasSidebarContent(current)) continue;
+      const tag = String(current.tagName || "").toLowerCase();
+      const className = String(current.className || "");
+      const testId = String(current.getAttribute?.("data-testid") || current.getAttribute?.("data-test-id") || "");
+      if (
+        tag === "aside" ||
+        tag === "nav" ||
+        current.classList?.contains("app-shell-left-panel") ||
+        /sidebar|left-panel|side-panel/i.test(`${className} ${testId}`) ||
+        current.getAttribute?.("data-app-shell-focus-area") === "left-panel"
+      ) {
+        return current;
+      }
+    }
+    return null;
+  }
+
+  function markMobileSidebarPanel(panel) {
+    if (!panel || panel.nodeType !== 1) return null;
+    panel.classList.add("codex-mobile-sidebar-panel");
+    panel.setAttribute("data-codex-mobile-sidebar-panel", "true");
+    return panel;
+  }
+
+  function ensureMobileSidebarPanel() {
+    const existing = document.querySelector(".codex-mobile-sidebar-panel,.app-shell-left-panel");
+    if (existing) return markMobileSidebarPanel(existing);
+    const directSelectors = [
+      "[data-app-shell-focus-area='left-panel']",
+      "[data-testid*='sidebar']",
+      "[data-test-id*='sidebar']",
+      "[class*='sidebar']",
+      "aside",
+      SIDEBAR_SCROLL_SELECTOR,
+      "nav",
+    ];
+    for (const selector of directSelectors) {
+      for (const candidate of Array.from(document.querySelectorAll(selector))) {
+        const panel = sidebarContainerFromNode(candidate);
+        if (panel) return markMobileSidebarPanel(panel);
+      }
+    }
+    return null;
+  }
+
+  function ensureMobileSidebarControls() {
+    if (!isLikelyMobileKeyboardDevice()) return;
+    ensureMobileSidebarPanel();
+    if (!document.getElementById("codex-mobile-sidebar-backdrop")) {
+      const backdrop = document.createElement("button");
+      backdrop.id = "codex-mobile-sidebar-backdrop";
+      backdrop.type = "button";
+      backdrop.tabIndex = -1;
+      backdrop.setAttribute("aria-label", "关闭会话栏");
+      backdrop.addEventListener("click", () => setMobileSidebarOpen(false));
+      document.body.appendChild(backdrop);
+    }
+    if (!document.getElementById("codex-mobile-sidebar-button")) {
+      const button = document.createElement("button");
+      button.id = "codex-mobile-sidebar-button";
+      button.type = "button";
+      button.textContent = "会话";
+      button.setAttribute("aria-label", "打开会话栏");
+      button.setAttribute("aria-expanded", "false");
+      button.addEventListener("click", toggleMobileSidebar);
+      document.body.appendChild(button);
+    }
+    if (!document.getElementById("codex-mobile-panel-controls")) {
+      const controls = document.createElement("div");
+      controls.id = "codex-mobile-panel-controls";
+      const side = document.createElement("button");
+      side.type = "button";
+      side.textContent = "侧";
+      side.setAttribute("aria-label", "切换右侧面板");
+      side.addEventListener("click", () => toggleOfficialPanel("side"));
+      const bottom = document.createElement("button");
+      bottom.type = "button";
+      bottom.textContent = "底";
+      bottom.setAttribute("aria-label", "切换底部面板");
+      bottom.addEventListener("click", () => toggleOfficialPanel("bottom"));
+      controls.appendChild(side);
+      controls.appendChild(bottom);
+      document.body.appendChild(controls);
+    }
+  }
+
+  function installMobileSidebarDrawer() {
+    if (!document || document.__codexMobileSidebarDrawerInstalled) return;
+    document.__codexMobileSidebarDrawerInstalled = true;
+    const start = () => {
+      ensureMobileSidebarControls();
+      const observer = new MutationObserver(() => ensureMobileSidebarControls());
+      observer.observe(document.documentElement, { childList: true, subtree: true });
+    };
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", start, { once: true });
+    } else {
+      start();
+    }
+    w.addEventListener("resize", ensureMobileSidebarControls, { passive: true });
+    w.addEventListener("orientationchange", () => setMobileSidebarOpen(false), { passive: true });
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") setMobileSidebarOpen(false);
+    });
+  }
+
+  installMobileSidebarDrawer();
+
   function visibleElement(element) {
     if (!element || typeof element.getBoundingClientRect !== "function") return false;
     const rect = element.getBoundingClientRect();
@@ -659,7 +1161,11 @@
   }
 
   function sidebarPanelElement() {
-    return document.querySelector(".app-shell-left-panel");
+    return (
+      document.querySelector(".codex-mobile-sidebar-panel") ||
+      document.querySelector(".app-shell-left-panel") ||
+      ensureMobileSidebarPanel()
+    );
   }
 
   function sidebarNavigationElement() {
@@ -988,9 +1494,9 @@
     if (mobileSidebarCollapseTimer) w.clearTimeout(mobileSidebarCollapseTimer);
     mobileSidebarCollapseTimer = w.setTimeout(() => {
       mobileSidebarCollapseTimer = null;
+      setMobileSidebarOpen(false);
       const panel = sidebarPanelElement();
       if (!panel || !visibleElement(panel)) return;
-      toggleLeftSidebar();
     }, MOBILE_SIDEBAR_AUTO_COLLAPSE_DELAY_MS);
   }
 


### PR DESCRIPTION
## Summary
- Add Windows build support for the OpenCodex shell, including Windows Store Codex discovery and Windows path normalization fixes.
- Add an Android WebView shell for phone usage, including local URL setup, mobile layout adjustments, drawer/session access, and adaptive/round launcher icons.
- Add IPC compatibility fixes for app-server channels used by the web shell.

## Testing
- `node --check web-shell/codex-bridge-polyfill.js`
- `pnpm run build`
- `gradle -p android-shell --no-daemon assembleDebug`
- `apksigner verify --verbose release/OpenCodex-android-debug.apk`

## Release artifacts
A test release with Windows and Android binaries is available on my fork:
https://github.com/david-zdw/OpenCodex/releases/tag/windows-android-2026-05-24

## Notes
This branch is based on the mobile composer work from the madrays fork and adds Windows/Android packaging on top.