### PR TITLE
Fix PWA install behind Cloudflare Access

### DIFF
--- a/gateway/runtime/http/static-assets.cjs
+++ b/gateway/runtime/http/static-assets.cjs
@@ -95,9 +95,10 @@ function createStaticAssetService({ getI18nSnapshot, getOfficialBundle }) {
     // 官方产物里的相对路径统一映射到 /official/，避免和 web-shell 自己的 /assets 冲突。
     html = html.replace(/(src|href)=["']\/(?!(?:official|assets)\/)([^"'#?]+)["']/g, '$1="/official/$2"');
     html = html.replace(/(src|href)=["']\.\/([^"'#?]+)["']/g, '$1="/official/$2"');
+    // manifest 在 Cloudflare Access 等前置认证后面也必须带同源凭据，否则 Chrome 可能拿不到受保护的 manifest。
     const base = [
       '<base href="/official/">',
-      `<link rel="manifest" href="${PWA_MANIFEST_PATH}">`,
+      `<link rel="manifest" href="${PWA_MANIFEST_PATH}" crossorigin="use-credentials">`,
       '<meta name="theme-color" content="#ffffff">',
       '<meta name="application-name" content="OpenCodex">',
       '<meta name="mobile-web-app-capable" content="yes">',
@@ -132,10 +133,27 @@ function createStaticAssetService({ getI18nSnapshot, getOfficialBundle }) {
 
   /** desktop HTML 的 CSP 会拦截浏览器里部分依赖的 Function/eval 探测，需要在 gateway 层放开。 */
   function patchOfficialCspForWeb(rawHtml) {
-    if (rawHtml.includes("&#39;unsafe-eval&#39;") || rawHtml.includes("'unsafe-eval'")) return rawHtml;
-    return rawHtml
-      .replace("&#39;wasm-unsafe-eval&#39;", "&#39;wasm-unsafe-eval&#39; &#39;unsafe-eval&#39;")
-      .replace("'wasm-unsafe-eval'", "'wasm-unsafe-eval' 'unsafe-eval'");
+    let html = rawHtml;
+    if (!html.includes("&#39;unsafe-eval&#39;") && !html.includes("'unsafe-eval'")) {
+      html = html
+        .replace("&#39;wasm-unsafe-eval&#39;", "&#39;wasm-unsafe-eval&#39; &#39;unsafe-eval&#39;")
+        .replace("'wasm-unsafe-eval'", "'wasm-unsafe-eval' 'unsafe-eval'");
+    }
+    return patchOfficialCspManifestSrc(html);
+  }
+
+  function patchOfficialCspManifestSrc(rawHtml) {
+    const cspMetaPattern =
+      /(<meta\b(?=[^>]*\bhttp-equiv=["']Content-Security-Policy["'])(?=[^>]*\bcontent=(["']))[^>]*\bcontent=\2)([\s\S]*?)(\2[^>]*>)/i;
+    return rawHtml.replace(cspMetaPattern, (match, start, _quote, content, end) => {
+      if (/\bmanifest-src\b/i.test(content)) return match;
+      const trimmedContent = content.trimEnd();
+      const trailingWhitespace = content.slice(trimmedContent.length);
+      const separator = trimmedContent.endsWith(";") ? " " : "; ";
+      const selfSource = content.includes("&#39;") ? "&#39;self&#39;" : "'self'";
+      // 官方 CSP 默认 default-src 'none'，必须显式允许 manifest，否则 Chrome 会把 PWA 视为 no-manifest。
+      return `${start}${trimmedContent}${separator}manifest-src ${selfSource};${trailingWhitespace}${end}`;
+    });
   }
 
   function patchOfficialHtmlForWeb(rawHtml) {

--- a/gateway/test/static-assets.test.cjs
+++ b/gateway/test/static-assets.test.cjs
@@ -1,0 +1,62 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const { createStaticAssetService } = require("../runtime/http/static-assets.cjs");
+
+const WEB_SHELL_INDEX = path.resolve(__dirname, "..", "..", "web-shell", "index.html");
+
+function makeTempDir(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "opencodex-static-assets-test-"));
+  t.after(() => fs.rmSync(dir, { force: true, recursive: true }));
+  return dir;
+}
+
+function createService(webviewDir) {
+  return createStaticAssetService({
+    getI18nSnapshot: () => ({ locale: "en-US", messages: {} }),
+    getOfficialBundle: () => ({ webviewDir }),
+  });
+}
+
+test("web shell manifest requests credentials for protected origins", () => {
+  const html = fs.readFileSync(WEB_SHELL_INDEX, "utf-8");
+
+  assert.match(html, /<link rel="manifest" href="\/manifest\.webmanifest" crossorigin="use-credentials" \/>/);
+});
+
+test("patched official renderer CSP allows the injected PWA manifest", (t) => {
+  const webviewDir = makeTempDir(t);
+  fs.writeFileSync(
+    path.join(webviewDir, "index.html"),
+    [
+      "<!doctype html>",
+      '<html><head><meta http-equiv="Content-Security-Policy" content="default-src &#39;none&#39;; worker-src &#39;self&#39; blob:; script-src &#39;self&#39; &#39;wasm-unsafe-eval&#39;;">',
+      "<title>Codex</title></head><body></body></html>",
+    ].join("")
+  );
+
+  const html = createService(webviewDir).createRendererResponse();
+
+  assert.match(html, /<link rel="manifest" href="\/manifest\.webmanifest" crossorigin="use-credentials">/);
+  assert.match(html, /manifest-src &#39;self&#39;;/);
+  assert.match(html, /&#39;wasm-unsafe-eval&#39; &#39;unsafe-eval&#39;/);
+});
+
+test("patched official renderer CSP does not duplicate an existing manifest-src", (t) => {
+  const webviewDir = makeTempDir(t);
+  fs.writeFileSync(
+    path.join(webviewDir, "index.html"),
+    [
+      "<!doctype html>",
+      '<html><head><meta http-equiv="Content-Security-Policy" content="default-src &#39;none&#39;; manifest-src &#39;self&#39;; script-src &#39;self&#39; &#39;wasm-unsafe-eval&#39;;">',
+      "<title>Codex</title></head><body></body></html>",
+    ].join("")
+  );
+
+  const html = createService(webviewDir).createRendererResponse();
+  const manifestDirectiveCount = html.match(/\bmanifest-src\b/g).length;
+
+  assert.equal(manifestDirectiveCount, 1);
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "sync": "pnpm run sync:version",
     "sync:version": "node scripts/sync-app-version.cjs",
     "check:version": "node scripts/sync-app-version.cjs --check",
-    "test": "node --test gateway/test/auth-rate-limit.test.cjs gateway/test/http-utils.test.cjs gateway/test/workspace-roots.test.cjs launcher/test/log-writer.test.cjs",
+    "test": "node --test gateway/test/auth-rate-limit.test.cjs gateway/test/http-utils.test.cjs gateway/test/static-assets.test.cjs gateway/test/workspace-roots.test.cjs launcher/test/log-writer.test.cjs",
     "web:dev": "pnpm run build:gateway && node gateway/dev/run-gateway.cjs",
     "build": "pnpm run build:gateway",
     "build:gateway": "pnpm run sync:version && node -e \"require('node:fs').rmSync('gateway/dist', { force: true, recursive: true })\" && tsc -p gateway/tsconfig.json",

--- a/web-shell/index.html
+++ b/web-shell/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content" />
     <meta http-equiv="Cache-Control" content="no-store" />
     <!-- PWA 元数据只提供可安装壳，不引入 Service Worker 或离线缓存。 -->
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="manifest" href="/manifest.webmanifest" crossorigin="use-credentials" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="application-name" content="OpenCodex" />
     <meta name="mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
## Summary
- Load both OpenCodex manifest links with `crossorigin="use-credentials"` so Chromium can include same-origin credentials when checking PWA installability.
- Apply the same manifest behavior to the patched official renderer HTML that OpenCodex serves after authentication.
- Add `manifest-src 'self'` to the patched official renderer CSP when the upstream desktop CSP does not already define it.
- Add static asset regression coverage for the credentialed manifest link and CSP patch.

## Problem
This fixes a PWA installability issue found when deploying OpenCodex behind Cloudflare Zero Trust / Access.

The local gateway works as expected when opened directly at the project default local address, for example:

```text
http://127.0.0.1:3737
```

In that local setup, Chromium can read the web app manifest and recognizes OpenCodex as installable.

However, when the same OpenCodex gateway is exposed through a Cloudflare Zero Trust protected HTTPS application, the page itself can load after the user completes Access authentication, but Chromium does not offer PWA installation. In other words:

- Local direct access: page loads and PWA installation is available.
- Cloudflare Zero Trust protected HTTPS access: page loads after authentication, but PWA installation is not available.

## Root cause
OpenCodex serves its PWA manifest from the same origin as the page. Behind Cloudflare Access or a similar same-origin authentication proxy, the manifest request is also protected by the access layer.

The previous manifest links did not declare a credentials mode:

```html
<link rel="manifest" href="/manifest.webmanifest">
```

For an authenticated protected origin, Chromium's installability check can fail to fetch or accept that manifest unless the link explicitly opts into credentialed fetching:

```html
<link rel="manifest" href="/manifest.webmanifest" crossorigin="use-credentials">
```

There is a second issue in the patched official renderer HTML. OpenCodex injects the manifest link into the official Codex renderer, but that renderer inherits the desktop CSP. When the upstream CSP uses `default-src 'none'` and does not define `manifest-src`, the injected manifest can still be blocked by CSP. The patched renderer therefore needs an explicit `manifest-src 'self'`.

## Changes
- Add `crossorigin="use-credentials"` to the web shell manifest link.
- Add `crossorigin="use-credentials"` to the manifest link injected into the patched official renderer.
- Keep the existing `unsafe-eval` CSP patch behavior, but also append `manifest-src 'self';` when the official renderer CSP does not already contain a `manifest-src` directive.
- Avoid duplicating `manifest-src` when the upstream CSP already provides one.
- Add tests for protected-origin manifest behavior and CSP patching.

## Testing
- `pnpm test`
- `pnpm run build:gateway`
- `git diff --check origin/main..HEAD`
- `node --check gateway/runtime/http/static-assets.cjs`
- `node --check gateway/test/static-assets.test.cjs`

## Manual validation
- Deployed the patch to a local packaged OpenCodex app and restarted the gateway.
- Verified the web shell includes the credentialed manifest link and does not contain the previous experimental top-level redirect.
- Verified the patched official renderer includes the credentialed manifest link and `manifest-src 'self'`.
- Verified a Cloudflare Zero Trust protected HTTPS deployment can be installed as a PWA after successful Access authentication.
