### PR TITLE
feat(runtime): synchronize conversation lists with native Codex

### DIFF
--- a/gateway/runtime/http/static-assets.cjs
+++ b/gateway/runtime/http/static-assets.cjs
@@ -367,6 +367,20 @@ function createStaticAssetService({ getI18nSnapshot, getOfficialBundle }) {
   }
 
   /** 对官方 chunk 做响应期 patch，不落盘改 vendor/官方构建产物。 */
+  function patchGpt56ModelPickerChunk(source) {
+    return source.replace(
+      /(harborEnabled:)[A-Za-z_$][\w$]*\((["'`])824038554\2\)(,isElectron:!0)/,
+      "$1!0$3"
+    );
+  }
+
+  function patchCatalogModelFilterChunk(source) {
+    if (!source.includes("availableModels") || !source.includes("useHiddenModels")) return source;
+    const allowlistFilter =
+      /if\s*\(\s*([A-Za-z_$][\w$]*)\s*\?\s*([A-Za-z_$][\w$]*)\.has\(\s*([A-Za-z_$][\w$]*)\.model\s*\)\s*:\s*!\s*\3\.hidden\s*\)/;
+    return source.replace(allowlistFilter, (_match, _flag, _set, item) => `if(!${item}.hidden)`);
+  }
+
   function patchOfficialAsset(reqPath, data, req) {
     if (!shouldPatchOfficialAsset(reqPath)) return data;
     const source = data.toString("utf-8");
@@ -376,6 +390,8 @@ function createStaticAssetService({ getI18nSnapshot, getOfficialBundle }) {
     if (!isLoopbackHostHeader(req && req.headers && req.headers.host)) {
       patched = patchOpenInFolderLocaleMessage(patched);
     }
+    patched = patchGpt56ModelPickerChunk(patched);
+    patched = patchCatalogModelFilterChunk(patched);
     return Buffer.from(patched, "utf-8");
   }
 

--- a/gateway/runtime/ipc/official-runtime.cjs
+++ b/gateway/runtime/ipc/official-runtime.cjs
@@ -1248,12 +1248,104 @@ function logUnknownIpc(kind, details) {
   } catch {}
 }
 
+const THREAD_LIST_INVALIDATION_METHODS = new Set([
+  "thread/started",
+  "thread/name",
+  "thread/name/updated",
+  "thread/archived",
+  "thread/unarchived",
+  "thread/deleted",
+]);
+const THREAD_LIST_BROADCAST_INVALIDATION_METHODS = new Set(["thread-archived", "thread-unarchived"]);
+
+function threadListInvalidationForOfficialMessage(channel, args, env = process.env) {
+  if (env.CODEX_WEB_THREAD_LIST_EVENT_SYNC === "0" || channel !== MESSAGE_FOR_VIEW_CHANNEL) return null;
+  const payload = payloadFromArgs(args);
+  if (!payload || typeof payload !== "object") return null;
+  const isAppServerListChange =
+    payload.type === "mcp-notification" && THREAD_LIST_INVALIDATION_METHODS.has(payload.method);
+  const isPeerListChange =
+    payload.type === "ipc-broadcast" && THREAD_LIST_BROADCAST_INVALIDATION_METHODS.has(payload.method);
+  const isPeerThreadSnapshot =
+    payload.type === "ipc-broadcast" &&
+    payload.method === "thread-stream-state-changed" &&
+    payload.params &&
+    payload.params.change &&
+    payload.params.change.type === "snapshot";
+  if (!isAppServerListChange && !isPeerListChange && !isPeerThreadSnapshot) return null;
+  return { type: "query-cache-invalidate", queryKey: ["recent-conversations-meta"] };
+}
+
+function threadListInvalidationEnvelope() {
+  const payload = {
+    type: "ipc-broadcast",
+    method: "query-cache-invalidate",
+    params: { queryKey: ["recent-conversations-meta"] },
+  };
+  return { channel: MESSAGE_FOR_VIEW_CHANNEL, payload, args: [payload] };
+}
+
+function threadListInvalidationRequest() {
+  return { type: "query-cache-invalidate", queryKey: ["recent-conversations-meta"] };
+}
+
+let threadListEventSyncScheduled = false;
+let threadListSyncInFlight = false;
+
+function runThreadListInvalidation(logEvent, details = {}) {
+  if (threadListSyncInFlight || !wsHub) return false;
+  threadListSyncInFlight = true;
+  try {
+    const recipientCount = wsHub.broadcast(threadListInvalidationEnvelope(), { suppressDiagnostic: true });
+    Promise.resolve(invokeOfficialIpc(MESSAGE_FROM_VIEW_CHANNEL, [threadListInvalidationRequest()])).catch((error) => {
+      diagnosticWarn("official-thread-list-sync", "recent_conversations_meta_native_invalidation_failed", {
+        error: error instanceof Error ? error.message : String(error || ""),
+        source: logEvent,
+      });
+    });
+    diagnosticLog("official-thread-list-sync", logEvent, { ...details, recipientCount });
+    return recipientCount > 0;
+  } catch (error) {
+    diagnosticWarn("official-thread-list-sync", "recent_conversations_meta_invalidation_failed", {
+      error: error instanceof Error ? error.message : String(error || ""),
+      source: logEvent,
+    });
+    return false;
+  } finally {
+    threadListSyncInFlight = false;
+  }
+}
+
+function scheduleThreadListEventSync(channel, args) {
+  const invalidation = threadListInvalidationForOfficialMessage(channel, args);
+  if (!invalidation || threadListEventSyncScheduled) return;
+  threadListEventSyncScheduled = true;
+  const notification = payloadFromArgs(args);
+  setImmediate(() => {
+    threadListEventSyncScheduled = false;
+    runThreadListInvalidation("recent_conversations_meta_invalidation_broadcast", {
+      hostId: typeof notification.hostId === "string" ? notification.hostId : "",
+      threadId:
+        notification.params &&
+        notification.params.thread &&
+        typeof notification.params.thread.id === "string"
+          ? notification.params.thread.id
+          : notification.params && typeof notification.params.conversationId === "string"
+            ? notification.params.conversationId
+            : notification.params && typeof notification.params.threadId === "string"
+              ? notification.params.threadId
+              : "",
+    });
+  });
+}
+
 function routeOfficialWebContentsSend(channel, args) {
   /**
    * 官方代码以为自己在给 Electron renderer 发消息。
    * gateway 需要把这些 webContents.send 拦下来，并转换成浏览器 WebSocket 消息。
-   */
+  */
   const payload = payloadFromArgs(args);
+  scheduleThreadListEventSync(channel, args);
   if (!wsHub) {
     diagnosticWarn("official-ipc-route", "before_ws_ready", outgoingIpcDiagnosticSummary(channel, args));
     logUnknownIpc("webcontents-send-before-ws-ready", {
@@ -1790,5 +1882,8 @@ module.exports = {
     shouldDropCorruptedThreadStreamStateChange,
     shouldIsolateOfficialLiveIpc,
     shouldInterceptRemoteFileManagerStore,
+    threadListInvalidationEnvelope,
+    threadListInvalidationRequest,
+    threadListInvalidationForOfficialMessage,
   },
 };

--- a/gateway/runtime/ipc/official-runtime.cjs
+++ b/gateway/runtime/ipc/official-runtime.cjs
@@ -316,11 +316,15 @@ function looksLikeOfficialCodexBinary(command, bundle, spawnOptions) {
 
 function isHiddenOfficialAppServerArgs(args) {
   /**
-   * 只识别官方 codex app-server 入口，不理解后续子命令或业务参数。
+   * 官方新版会在子命令前追加 `-c <配置>`；跳过成对的全局配置参数后再识别 app-server。
    * 参数保持原样透传给官方 Desktop 的 codex 二进制，保证官方新增/修改 app-server 参数时自动兼容。
    */
-  if (!Array.isArray(args) || args[0] !== "app-server") return false;
-  return true;
+  if (!Array.isArray(args)) return false;
+  let commandIndex = 0;
+  while ((args[commandIndex] === "-c" || args[commandIndex] === "--config") && commandIndex + 1 < args.length) {
+    commandIndex += 2;
+  }
+  return args[commandIndex] === "app-server";
 }
 
 function looksLikeComputerUseInstaller(command) {
@@ -532,26 +536,34 @@ function setOfficialPackagedMode() {
   } catch {}
 }
 
+function shouldIsolateOfficialLiveIpc(env = process.env) {
+  return env.CODEX_WEB_ISOLATE_OFFICIAL_LIVE_IPC === "1";
+}
+
 function alignOfficialElectronEnvironment(bundle) {
   /**
    * 官方 main 认为自己运行在已打包桌面应用中。
    * gateway 需要把 app path、resourcesPath、userData 和 build flavor 都伪装成官方生产环境，
    * 否则官方 bootstrap 会尝试连接开发服务器或找不到内置 codex 二进制。
-   */
+  */
   const runtimeUserDataDir = officialRuntimeUserDataDir();
-  const runtimeTempDir = officialRuntimeTempDir();
+  const isolateLiveIpc = shouldIsolateOfficialLiveIpc();
+  const runtimeTempDir = isolateLiveIpc ? officialRuntimeTempDir() : os.tmpdir();
   // CODEX_HOME 才是需要共享的核心数据；Electron profile 只保存运行态缓存，不能和官方桌面端抢同一把锁。
   ensureDir(runtimeUserDataDir);
-  // 官方跨进程 live IPC bus 基于 os.tmpdir() 建 socket；这里必须和官方 Desktop 隔离，避免抢会话 owner。
-  ensureDir(runtimeTempDir);
-  try {
-    fs.chmodSync(runtimeTempDir, 0o700);
-  } catch {}
+  if (isolateLiveIpc) {
+    ensureDir(runtimeTempDir);
+    try {
+      fs.chmodSync(runtimeTempDir, 0o700);
+    } catch {}
+  }
   process.env.CODEX_ELECTRON_USER_DATA_PATH = process.env.CODEX_ELECTRON_USER_DATA_PATH || runtimeUserDataDir;
   process.env.CODEX_HOME = process.env.CODEX_HOME || CODEX_HOME;
-  process.env.TMPDIR = runtimeTempDir;
-  process.env.TMP = runtimeTempDir;
-  process.env.TEMP = runtimeTempDir;
+  if (isolateLiveIpc) {
+    process.env.TMPDIR = runtimeTempDir;
+    process.env.TMP = runtimeTempDir;
+    process.env.TEMP = runtimeTempDir;
+  }
   process.env.NODE_ENV = process.env.NODE_ENV || "production";
   // 官方 main 在开发态会从环境/package metadata 推导 build flavor；gateway 明确按 prod 对齐。
   process.env.BUILD_FLAVOR = process.env.BUILD_FLAVOR || "prod";
@@ -576,7 +588,10 @@ function alignOfficialElectronEnvironment(bundle) {
   } catch {}
   diagnosticLog("official-runtime", "official_runtime_temp_dir_configured", {
     runtimeTempDir,
-    reason: "isolate official live ipc bus from Codex Desktop",
+    mode: isolateLiveIpc ? "isolated" : "shared",
+    reason: isolateLiveIpc
+      ? "isolate official live ipc bus from Codex Desktop"
+      : "share official live ipc bus with Codex Desktop",
   });
   diagnosticLog("official-runtime", "official_runtime_resources_configured", {
     resourcesPath: officialResourcesPath,
@@ -917,6 +932,35 @@ function payloadFromArgs(args) {
 
 function normalizeIpcArgs(args) {
   return Array.isArray(args) ? args : [args];
+}
+
+const CORRUPTED_THREAD_STREAM_REFERENCE_KEYS = new Set([
+  "activePermissionProfile",
+  "attachments",
+  "collaborationMode",
+  "input",
+  "items",
+  "requests",
+  "runtimeWorkspaceRoots",
+  "sandboxPolicy",
+  "turns",
+  "writableRoots",
+]);
+
+function containsCircularSentinel(value, key = "", seen = new WeakSet()) {
+  if (value === "[Circular]") return CORRUPTED_THREAD_STREAM_REFERENCE_KEYS.has(key);
+  if (value == null || typeof value !== "object") return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+  if (Array.isArray(value)) return value.some((item) => containsCircularSentinel(item, key, seen));
+  return Object.entries(value).some(([nestedKey, item]) => containsCircularSentinel(item, nestedKey, seen));
+}
+
+function shouldDropCorruptedThreadStreamStateChange(channel, args) {
+  if (channel !== MESSAGE_FROM_VIEW_CHANNEL) return false;
+  const message = payloadFromArgs(normalizeIpcArgs(args));
+  if (!message || typeof message !== "object" || message.type !== "thread-stream-state-changed") return false;
+  return containsCircularSentinel(message);
 }
 
 function stringRouteId(value) {
@@ -1438,6 +1482,13 @@ async function invokeOfficialIpc(channel, args = [], context = {}) {
   await waitForOfficialBridgeReady();
   const event = createOfficialIpcEvent(context);
   const invokeArgs = normalizeIpcArgs(args);
+  if (shouldDropCorruptedThreadStreamStateChange(channel, invokeArgs)) {
+    const message = payloadFromArgs(invokeArgs);
+    diagnosticWarn("official-ipc-route", "corrupted_thread_stream_snapshot_dropped", {
+      conversationId: message && typeof message.conversationId === "string" ? message.conversationId : "",
+    });
+    return true;
+  }
   // 先记录请求归属，再调用官方 handler，这样同步和异步回包都能找到目标 client。
   rememberRequestRoute(channel, invokeArgs, context.clientId || "");
   // Computer Use 锁屏授权由官方 Installer 决定；这里额外记录同进程直接 status，方便和官方回包对照。
@@ -1735,6 +1786,9 @@ module.exports = {
   webConfigScript,
   __test: {
     fileManagerPathFromSpawn,
+    isHiddenOfficialAppServerArgs,
+    shouldDropCorruptedThreadStreamStateChange,
+    shouldIsolateOfficialLiveIpc,
     shouldInterceptRemoteFileManagerStore,
   },
 };

--- a/gateway/test/official-runtime.test.cjs
+++ b/gateway/test/official-runtime.test.cjs
@@ -35,6 +35,59 @@ test("recognizes platform file manager spawn targets", () => {
   assert.equal(__test.fileManagerPathFromSpawn("node", ["script.js"]), "");
 });
 
+test("recognizes official app-server arguments after global config flags", () => {
+  assert.equal(__test.isHiddenOfficialAppServerArgs(["app-server", "--analytics-default-enabled"]), true);
+  assert.equal(
+    __test.isHiddenOfficialAppServerArgs([
+      "-c",
+      "features.code_mode_host=true",
+      "app-server",
+      "--analytics-default-enabled",
+    ]),
+    true
+  );
+  assert.equal(__test.isHiddenOfficialAppServerArgs(["-c", "app-server"]), false);
+  assert.equal(__test.isHiddenOfficialAppServerArgs(["exec", "app-server"]), false);
+});
+
+test("shares the official live IPC bus unless isolation is explicitly requested", () => {
+  assert.equal(__test.shouldIsolateOfficialLiveIpc({}), false);
+  assert.equal(__test.shouldIsolateOfficialLiveIpc({ CODEX_WEB_ISOLATE_OFFICIAL_LIVE_IPC: "0" }), false);
+  assert.equal(__test.shouldIsolateOfficialLiveIpc({ CODEX_WEB_ISOLATE_OFFICIAL_LIVE_IPC: "1" }), true);
+});
+
+test("drops corrupted thread stream snapshots from stale browser clients", () => {
+  const channel = "codex_desktop:message-from-view";
+  assert.equal(
+    __test.shouldDropCorruptedThreadStreamStateChange(channel, [
+      {
+        type: "thread-stream-state-changed",
+        conversationId: "thread-1",
+        change: {
+          type: "snapshot",
+          conversationState: {
+            currentPermissions: { runtimeWorkspaceRoots: ["C:\\workspace"] },
+            latestThreadSettings: { runtimeWorkspaceRoots: "[Circular]" },
+          },
+        },
+      },
+    ]),
+    true
+  );
+  assert.equal(
+    __test.shouldDropCorruptedThreadStreamStateChange(channel, [
+      {
+        type: "thread-stream-state-changed",
+        change: {
+          type: "snapshot",
+          conversationState: { runtimeWorkspaceRoots: ["C:\\workspace"], title: "[Circular]" },
+        },
+      },
+    ]),
+    false
+  );
+});
+
 test("vscode fetch open-file payloads feed the same interception condition", () => {
   const openFileTarget = openFileTargetFromIpc("codex_desktop:message-from-view", {
     type: "fetch",

--- a/gateway/test/official-runtime.test.cjs
+++ b/gateway/test/official-runtime.test.cjs
@@ -56,6 +56,91 @@ test("shares the official live IPC bus unless isolation is explicitly requested"
   assert.equal(__test.shouldIsolateOfficialLiveIpc({ CODEX_WEB_ISOLATE_OFFICIAL_LIVE_IPC: "1" }), true);
 });
 
+test("bridges official thread list changes to recent conversation metadata invalidation", () => {
+  const channel = "codex_desktop:message-for-view";
+  const expected = { type: "query-cache-invalidate", queryKey: ["recent-conversations-meta"] };
+  const startedArgs = [
+    {
+      type: "mcp-notification",
+      hostId: "local",
+      method: "thread/started",
+      params: { thread: { id: "thread-1" } },
+    },
+  ];
+
+  assert.deepEqual(__test.threadListInvalidationForOfficialMessage(channel, startedArgs, {}), expected);
+  for (const method of [
+    "thread/name",
+    "thread/name/updated",
+    "thread/archived",
+    "thread/unarchived",
+    "thread/deleted",
+  ]) {
+    assert.deepEqual(
+      __test.threadListInvalidationForOfficialMessage(channel, [
+        { type: "mcp-notification", method, params: { threadId: "thread-1" } },
+      ]),
+      expected
+    );
+  }
+  assert.deepEqual(
+    __test.threadListInvalidationForOfficialMessage(channel, [
+      {
+        type: "ipc-broadcast",
+        method: "thread-stream-state-changed",
+        params: { conversationId: "thread-2", change: { type: "snapshot" } },
+      },
+    ]),
+    expected
+  );
+  assert.equal(
+    __test.threadListInvalidationForOfficialMessage(channel, [
+      {
+        type: "ipc-broadcast",
+        method: "thread-stream-state-changed",
+        params: { conversationId: "thread-2", change: { type: "delta" } },
+      },
+    ]),
+    null
+  );
+  assert.deepEqual(
+    __test.threadListInvalidationForOfficialMessage(channel, [
+      { type: "ipc-broadcast", method: "thread-archived", params: { conversationId: "thread-2" } },
+    ]),
+    expected
+  );
+  assert.equal(
+    __test.threadListInvalidationForOfficialMessage(channel, startedArgs, {
+      CODEX_WEB_THREAD_LIST_EVENT_SYNC: "0",
+    }),
+    null
+  );
+  assert.equal(
+    __test.threadListInvalidationForOfficialMessage(
+      channel,
+      [{ type: "mcp-notification", method: "turn/completed", params: {} }]
+    ),
+    null
+  );
+});
+
+test("uses the renderer-specific invalidation shape for each client", () => {
+  const payload = {
+    type: "ipc-broadcast",
+    method: "query-cache-invalidate",
+    params: { queryKey: ["recent-conversations-meta"] },
+  };
+  assert.deepEqual(__test.threadListInvalidationEnvelope(), {
+    channel: "codex_desktop:message-for-view",
+    payload,
+    args: [payload],
+  });
+  assert.deepEqual(__test.threadListInvalidationRequest(), {
+    type: "query-cache-invalidate",
+    queryKey: ["recent-conversations-meta"],
+  });
+});
+
 test("drops corrupted thread stream snapshots from stale browser clients", () => {
   const channel = "codex_desktop:message-from-view";
   assert.equal(

--- a/gateway/test/static-assets.test.cjs
+++ b/gateway/test/static-assets.test.cjs
@@ -7,6 +7,19 @@ const { PATCHED_OFFICIAL_PREFIX } = require("../runtime/core/config.cjs");
 const { createStaticAssetService } = require("../runtime/http/static-assets.cjs");
 
 const WEB_SHELL_INDEX = path.resolve(__dirname, "..", "..", "web-shell", "index.html");
+const CODEX_BRIDGE_POLYFILL = path.resolve(__dirname, "..", "..", "web-shell", "codex-bridge-polyfill.js");
+
+function loadBridgeStringifyForIpc() {
+  const source = fs.readFileSync(CODEX_BRIDGE_POLYFILL, "utf-8");
+  const match = source.match(
+    /  function stringifyForIpc\(value\) \{[\s\S]*?\r?\n  \}\r?\n\r?\n  const ipcErrorToastState/
+  );
+  assert.ok(match, "stringifyForIpc source should remain testable");
+  const functionSource = match[0]
+    .replace(/\r?\n\r?\n  const ipcErrorToastState$/, "")
+    .replace(/^  /gm, "");
+  return Function(`"use strict"; ${functionSource}; return stringifyForIpc;`)();
+}
 
 function makeTempDir(t) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "opencodex-static-assets-test-"));
@@ -54,6 +67,62 @@ test("web shell manifest requests credentials for protected origins", () => {
   const html = fs.readFileSync(WEB_SHELL_INDEX, "utf-8");
 
   assert.match(html, /<link rel="manifest" href="\/manifest\.webmanifest" crossorigin="use-credentials" \/>/);
+});
+
+test("IPC serialization preserves repeated arrays and only replaces real cycles", () => {
+  const stringifyForIpc = loadBridgeStringifyForIpc();
+  const roots = ["C:\\workspace"];
+  const sandboxPolicy = { type: "workspaceWrite", writableRoots: roots };
+  const payload = {
+    currentPermissions: { runtimeWorkspaceRoots: roots, sandboxPolicy },
+    latestThreadSettings: { runtimeWorkspaceRoots: roots, sandboxPolicy },
+  };
+  const parsed = JSON.parse(stringifyForIpc(payload));
+
+  assert.deepEqual(parsed.currentPermissions.runtimeWorkspaceRoots, roots);
+  assert.deepEqual(parsed.latestThreadSettings.runtimeWorkspaceRoots, roots);
+  assert.deepEqual(parsed.currentPermissions.sandboxPolicy, sandboxPolicy);
+  assert.deepEqual(parsed.latestThreadSettings.sandboxPolicy, sandboxPolicy);
+
+  const cyclic = { kind: "cycle" };
+  cyclic.self = cyclic;
+  assert.deepEqual(JSON.parse(stringifyForIpc(cyclic)), { kind: "cycle", self: "[Circular]" });
+});
+
+test("enables only the GPT-5.6 Harbor model picker in official chunks", (t) => {
+  const webviewDir = makeOfficialWebviewDir(t);
+  const assetsDir = path.join(webviewDir, "assets");
+  fs.mkdirSync(assetsDir, { recursive: true });
+  const assetName = "composer-test.js";
+  fs.writeFileSync(
+    path.join(assetsDir, assetName),
+    'const picker={harborEnabled:_r(`824038554`),isElectron:!0,otherGate:_r(`123456789`)};'
+  );
+  const service = createService(webviewDir);
+  const reqPath = `${PATCHED_OFFICIAL_PREFIX}assets/${assetName}`;
+
+  const source = serveOfficialAsset(service, reqPath, "localhost:3737");
+
+  assert.match(source, /harborEnabled:!0,isElectron:!0/);
+  assert.match(source, /otherGate:_r\(`123456789`\)/);
+});
+
+test("uses visible catalog models instead of the stale model allowlist", (t) => {
+  const webviewDir = makeOfficialWebviewDir(t);
+  const assetsDir = path.join(webviewDir, "assets");
+  fs.mkdirSync(assetsDir, { recursive: true });
+  const assetName = "model-list-filter-test.js";
+  fs.writeFileSync(
+    path.join(assetsDir, assetName),
+    "function filter({availableModels:n,useHiddenModels:s,models:o}){return o.forEach(r=>{if(s?n.has(r.model):!r.hidden){show(r)}if(r.pinned){pin(r)}})}"
+  );
+  const service = createService(webviewDir);
+  const reqPath = `${PATCHED_OFFICIAL_PREFIX}assets/${assetName}`;
+
+  const source = serveOfficialAsset(service, reqPath, "localhost:3737");
+
+  assert.match(source, /if\(!r\.hidden\)\{show\(r\)\}/);
+  assert.doesNotMatch(source, /s\?n\.has\(r\.model\):!r\.hidden/);
 });
 
 test("patched official renderer CSP allows the injected PWA manifest", (t) => {

--- a/web-shell/codex-bridge-polyfill.js
+++ b/web-shell/codex-bridge-polyfill.js
@@ -1148,8 +1148,8 @@
 
   /** 安全序列化 IPC payload，支持 Error 和循环引用。 */
   function stringifyForIpc(value) {
-    const seen = new WeakSet();
-    return JSON.stringify(value, (_key, nestedValue) => {
+    const ancestors = [];
+    return JSON.stringify(value, function (_key, nestedValue) {
       if (nestedValue instanceof Error) {
         return {
           name: nestedValue.name,
@@ -1159,8 +1159,9 @@
         };
       }
       if (nestedValue && typeof nestedValue === "object") {
-        if (seen.has(nestedValue)) return "[Circular]";
-        seen.add(nestedValue);
+        while (ancestors.length > 0 && ancestors.at(-1) !== this) ancestors.pop();
+        if (ancestors.includes(nestedValue)) return "[Circular]";
+        ancestors.push(nestedValue);
       }
       return nestedValue;
     });


### PR DESCRIPTION
## Purpose

Keep the OpenCodex and native Codex conversation lists synchronized in both directions without requiring a manual page refresh or application restart.

## Behavior

When either client creates, renames, archives, unarchives, or deletes a conversation, the official runtime event invalidates the active `recent-conversations-meta` cache in both clients.

- Native Codex -> OpenCodex: official app-server notifications and shared runtime snapshots refresh the OpenCodex sidebar.
- OpenCodex -> native Codex: OpenCodex-originated runtime events refresh the native Codex sidebar.
- Duplicate deliveries for the same change are coalesced into one event-driven refresh notification.

## Dependency

Draft. This branch currently includes the compatibility base from #22 plus this feature commit. It depends on #22 being merged first. After that merge, this branch will be rebased onto upstream `main`, leaving only the synchronization change for review.

## Verification

- `node --test gateway/test/official-runtime.test.cjs` (8 passing)
- `node --check gateway/runtime/ipc/official-runtime.cjs`
- Manually verified bidirectional conversation creation and archive-state list updates with the current Windows native client and OpenCodex.