### PR TITLE
fix(polyfill): support synchronous preload startup methods

### DIFF
--- a/gateway/test/official-desktop-compat.test.cjs
+++ b/gateway/test/official-desktop-compat.test.cjs
@@ -3,6 +3,7 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
+const vm = require("node:vm");
 
 const {
   CodexAsarScanner,
@@ -17,6 +18,21 @@ const {
 } = require("../dist/official/OfficialRuntimeEntryResolver.js");
 const { __test: layoutTest } = require("../runner/official-layout.cjs");
 
+const BRIDGE_POLYFILL_PATH = path.resolve(__dirname, "..", "..", "web-shell", "codex-bridge-polyfill.js");
+
+function loadAttachBridge() {
+  const source = fs.readFileSync(BRIDGE_POLYFILL_PATH, "utf8");
+  const start = source.indexOf("  function attachBridge(target) {");
+  const end = source.indexOf("\n  const BRIDGE_FALLBACK_UNDEFINED_PROPS", start);
+  assert.notEqual(start, -1);
+  assert.notEqual(end, -1);
+  // 直接执行生产代码中的 bridge 安装函数，避免复制实现后让测试与真实 polyfill 漂移。
+  return vm.runInNewContext(`${source.slice(start, end)}\nattachBridge`, {
+    invoke() {},
+    performance: { timeOrigin: 1234 },
+  });
+}
+
 function temporaryDirectory(t) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "opencodex-desktop-compat-"));
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
@@ -27,6 +43,17 @@ function writeFile(filePath, content = "fixture") {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, content);
 }
+
+test("bridge exposes synchronous preload startup methods", () => {
+  const attachBridge = loadAttachBridge();
+  const bridge = {};
+
+  attachBridge(bridge);
+
+  assert.equal(bridge.getPreloadStartedAtMs(), 1234);
+  assert.equal(bridge.getInitialSidebarBootstrap(), null);
+  assert.equal(bridge.isDeviceCheckSupported(), false);
+});
 
 test("macOS default candidates prefer ChatGPT while retaining Codex paths", () => {
   const fileSystem = { normalizePath: (value) => value };

--- a/web-shell/codex-bridge-polyfill.js
+++ b/web-shell/codex-bridge-polyfill.js
@@ -2431,6 +2431,10 @@
     };
     target.getPlatform = () => "web";
     target.getVersion = () => "web-poc";
+    // renderer 会同步读取这些 preload 能力，不能落到返回 Promise 的通用 IPC fallback。
+    target.getPreloadStartedAtMs = () => performance.timeOrigin;
+    target.getInitialSidebarBootstrap = () => null;
+    target.isDeviceCheckSupported = () => false;
     // 对齐官方 preload 暴露的基础字段，避免新版 renderer 走 fallback IPC 后报 missing handler。
     target.windowType = "electron";
     target.openExternal = (url) => openExternal(url);


### PR DESCRIPTION
Fixes #24.

## Summary

- expose synchronous `getPreloadStartedAtMs()`, `getInitialSidebarBootstrap()`, and `isDeviceCheckSupported()` implementations in the web bridge
- prevent these preload-only calls from falling through to the Promise-based IPC proxy
- execute the production `attachBridge` implementation in a regression test

## Verification

- `pnpm test` — 56/56 passing
- verified against ChatGPT Desktop 26.721.41059 (build 5848) on macOS arm64
- verified a password-authenticated web login at a 375×812 viewport reaches the Codex composer without the error boundary or missing-handler errors
