### PR TITLE
perf(gateway): cache versioned patched assets

### DIFF
--- a/gateway/runtime/http/static-assets.cjs
+++ b/gateway/runtime/http/static-assets.cjs
@@ -416,7 +416,8 @@ function createStaticAssetService({ getI18nSnapshot, getOfficialBundle }) {
     if (!isLoopbackHostHeader(req && req.headers && req.headers.host)) {
       patched = patchOpenInFolderLocaleMessage(patched);
     }
-    return Buffer.from(patched, "utf-8");
+    // 保留原 Buffer 身份，让缓存层能区分 content-hash 源文件与动态改写后的响应体。
+    return patched === source ? data : Buffer.from(patched, "utf-8");
   }
 
   /** 将 URL path 映射到 web-shell 或官方 asset 的真实文件。 */
@@ -445,10 +446,18 @@ function createStaticAssetService({ getI18nSnapshot, getOfficialBundle }) {
   }
 
   /** 静态资源缓存策略：hash asset 长缓存，入口 HTML/no-store 保持可更新。 */
-  function cacheControlForRequestPath(reqPath) {
+  function cacheControlForRequestPath(reqPath, responsePatched = false) {
     if (process.env.CODEX_WEB_DISABLE_ASSET_CACHE === "1") return "no-store";
     if (patchedOfficialAssetName(reqPath)) {
-      // patched chunk 的内容由 gateway 响应期生成，旧前缀也必须 no-store，避免跨版本继续吃旧模块图。
+      // patched 前缀不包含官方 runtime 版本，只有 Vite content-hash 文件名能安全跨升级长期缓存。
+      if (
+        reqPath.startsWith(PATCHED_OFFICIAL_PREFIX) &&
+        !responsePatched &&
+        /-[A-Za-z0-9_-]{8}\.js$/.test(patchedOfficialAssetName(reqPath))
+      ) {
+        return "public, max-age=31536000, immutable";
+      }
+      // 旧前缀没有可靠版本位，只用于兼容浏览器残留的懒加载请求。
       return "no-store";
     }
     if (reqPath.startsWith("/official/assets/")) return "public, max-age=31536000, immutable";
@@ -459,10 +468,14 @@ function createStaticAssetService({ getI18nSnapshot, getOfficialBundle }) {
 
   /** 发送静态文件，并按路径套用合适的缓存策略。 */
   function serveFile(req, res, file, status = 200, reqPath = "") {
-    const data = patchOfficialAsset(reqPath, fs.readFileSync(file), req);
+    const sourceData = fs.readFileSync(file);
+    const data = patchOfficialAsset(reqPath, sourceData, req);
     const response = gzipIfUseful(
       req,
-      { "content-type": mimeType(file), "cache-control": cacheControlForRequestPath(reqPath) },
+      {
+        "content-type": mimeType(file),
+        "cache-control": cacheControlForRequestPath(reqPath, data !== sourceData),
+      },
       data
     );
     send(res, status, response.headers, response.body);

--- a/gateway/test/static-assets.test.cjs
+++ b/gateway/test/static-assets.test.cjs
@@ -94,6 +94,13 @@ function serveOfficialAsset(service, reqPath, host) {
   return res.body.toString("utf-8");
 }
 
+function serveOfficialAssetResponse(service, reqPath, host = "localhost:3737") {
+  const file = service.staticFile(reqPath);
+  const res = makeResponseRecorder();
+  service.serveFile({ headers: { host } }, res, file, 200, reqPath);
+  return res;
+}
+
 test("web shell manifest requests credentials for protected origins", () => {
   const html = fs.readFileSync(WEB_SHELL_INDEX, "utf-8");
 
@@ -352,4 +359,39 @@ test("renames official open-in-folder locale message only for remote browser hos
 
   const loopbackSource = serveOfficialAsset(service, reqPath, "localhost:3737");
   assert.match(loopbackSource, /"artifactTab\.preview\.openInFolder":`打开所在文件夹`/);
+});
+
+test("only caches content-hashed patched assets as immutable", (t) => {
+  const webviewDir = makeOfficialWebviewDir(t);
+  const assetsDir = path.join(webviewDir, "assets");
+  fs.mkdirSync(assetsDir, { recursive: true });
+  fs.writeFileSync(path.join(assetsDir, "app-Dk3EPlSk.js"), "export const ready = true;");
+  fs.writeFileSync(
+    path.join(assetsDir, "locale-Ab1_cdEF.js"),
+    'export default {"artifactTab.preview.openInFolder":"Open in folder"};'
+  );
+  fs.writeFileSync(path.join(assetsDir, "dotnet.js"), "export const runtime = true;");
+  const service = createService(webviewDir);
+  const patchedService = createStaticAssetService({
+    getI18nSnapshot: () => ({
+      locale: "zh-CN",
+      messages: { "web.remoteFile.downloadFile": "下载文件" },
+    }),
+    getOfficialBundle: () => ({ webviewDir }),
+  });
+
+  const current = serveOfficialAssetResponse(service, `${PATCHED_OFFICIAL_PREFIX}assets/app-Dk3EPlSk.js`);
+  const dynamic = serveOfficialAssetResponse(
+    patchedService,
+    `${PATCHED_OFFICIAL_PREFIX}assets/locale-Ab1_cdEF.js`,
+    "192.168.60.218:3737"
+  );
+  const fixedName = serveOfficialAssetResponse(service, `${PATCHED_OFFICIAL_PREFIX}assets/dotnet.js`);
+  const legacy = serveOfficialAssetResponse(service, "/official-patched/assets/app-Dk3EPlSk.js");
+
+  assert.equal(current.headers["cache-control"], "public, max-age=31536000, immutable");
+  assert.equal(dynamic.headers["cache-control"], "no-store");
+  assert.match(dynamic.body.toString("utf-8"), /下载文件/);
+  assert.equal(fixedName.headers["cache-control"], "no-store");
+  assert.equal(legacy.headers["cache-control"], "no-store");
 });


### PR DESCRIPTION
Closes #29

## What changed

- Serve the current versioned patched asset namespace with one-year immutable caching.
- Keep the legacy unversioned patched prefix on `no-store`.
- Add a regression test for both response headers.

## Why

Large patched renderer chunks were downloaded through remote tunnels on every refresh even though both the patch namespace and official asset filename provide cache-busting identifiers.

## Validation

- `pnpm test` — 105 tests passed
- `git diff --check HEAD^ HEAD`
