### PR TITLE
fix(mobile): restore scrolling and browser copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenCodex",
   "main": "launcher/main.cjs",
   "author": "Ryens",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "OpenCodex is a middleware layer for Codex Desktop. It lets you use a phone, tablet, or another computer to access and operate Codex on a target machine through a browser, making it suitable for continuous AI Coding in LAN or remote LAN environments.",
   "private": true,
   "scripts": {
@@ -48,6 +48,9 @@
     "productName": "OpenCodex",
     "asar": false,
     "icon": "web-shell/assets/icon.png",
+    "toolsets": {
+      "winCodeSign": "1.1.0"
+    },
     "directories": {
       "output": "release"
     },

--- a/shared/app-version.cjs
+++ b/shared/app-version.cjs
@@ -1,7 +1,7 @@
 "use strict";
 
 // 此文件由 pnpm run sync:version 生成；请修改 package.json version 后重新同步。
-const OPENCODEX_VERSION = "2.0.3";
+const OPENCODEX_VERSION = "2.0.4";
 const OPENCODEX_VERSION_LABEL = `v${OPENCODEX_VERSION}`;
 
 module.exports = {

--- a/shared/i18n/locales/en-US.json
+++ b/shared/i18n/locales/en-US.json
@@ -83,6 +83,7 @@
   "web.auth.logoutGatewayFailed": "OpenCodex logout failed: {error}",
   "web.remoteFile.downloadFile": "Download file",
   "web.remoteFile.downloadFailed": "Unable to download this file.",
+  "web.clipboard.manualCopy": "The browser could not write to the clipboard. Select and copy the text below:",
   "web.settings.open": "Settings",
   "web.settings.title": "Settings",
   "web.settings.close": "Close settings",

--- a/shared/i18n/locales/zh-CN.json
+++ b/shared/i18n/locales/zh-CN.json
@@ -83,6 +83,7 @@
   "web.auth.logoutGatewayFailed": "退出认证失败：{error}",
   "web.remoteFile.downloadFile": "下载文件",
   "web.remoteFile.downloadFailed": "无法下载该文件。",
+  "web.clipboard.manualCopy": "浏览器无法自动写入剪贴板，请长按选择并复制以下内容：",
   "web.settings.open": "设置",
   "web.settings.title": "设置",
   "web.settings.close": "关闭设置",

--- a/web-shell/codex-bridge-polyfill.js
+++ b/web-shell/codex-bridge-polyfill.js
@@ -212,8 +212,187 @@
     }
   }
 
+  let browserClipboardCapability = null;
+
+  /** 在局域网 HTTP 和受限权限环境中把复制保留在当前浏览器，不转发到宿主机剪贴板。 */
+  function installBrowserClipboard() {
+    const nav = w.navigator;
+    if (!nav || w.__OpenCodexBrowserClipboardInstalled) return;
+
+    const nativeClipboard = nav.clipboard || null;
+    const nativeWriteText =
+      nativeClipboard && typeof nativeClipboard.writeText === "function"
+        ? nativeClipboard.writeText.bind(nativeClipboard)
+        : null;
+    const nativeWrite =
+      nativeClipboard && typeof nativeClipboard.write === "function"
+        ? nativeClipboard.write.bind(nativeClipboard)
+        : null;
+    const nativeReadText =
+      nativeClipboard && typeof nativeClipboard.readText === "function"
+        ? nativeClipboard.readText.bind(nativeClipboard)
+        : null;
+    const nativeRead =
+      nativeClipboard && typeof nativeClipboard.read === "function"
+        ? nativeClipboard.read.bind(nativeClipboard)
+        : null;
+
+    const diagnostics = {
+      secureContext: w.isSecureContext === true,
+      asyncClipboard: !!nativeWriteText,
+      origin: location.origin,
+      installed: false,
+      lastPath: null,
+      lastError: null,
+    };
+    w.__OpenCodexClipboardDiagnostics = diagnostics;
+
+    const recordClipboardPath = (path, error) => {
+      diagnostics.lastPath = path;
+      diagnostics.lastError = error ? (error instanceof Error ? error.message : String(error)) : null;
+      try {
+        clientDiagnostic("clipboard-write", {
+          path,
+          secureContext: diagnostics.secureContext,
+          asyncClipboard: diagnostics.asyncClipboard,
+          errorName: error && error.name ? String(error.name) : "",
+        });
+      } catch {}
+    };
+
+    const legacySelectionCopy = (text) => {
+      if (!document.body || typeof document.execCommand !== "function") return false;
+      const active = document.activeElement;
+      const selection = typeof w.getSelection === "function" ? w.getSelection() : null;
+      const savedRanges = [];
+      if (selection) {
+        for (let index = 0; index < selection.rangeCount; index += 1) {
+          savedRanges.push(selection.getRangeAt(index).cloneRange());
+        }
+      }
+
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.setAttribute("readonly", "");
+      textarea.setAttribute("aria-hidden", "true");
+      textarea.style.position = "fixed";
+      textarea.style.top = "0";
+      textarea.style.left = "-9999px";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+
+      let copied = false;
+      try {
+        textarea.focus({ preventScroll: true });
+        textarea.select();
+        textarea.setSelectionRange(0, textarea.value.length);
+        copied = document.execCommand("copy") === true;
+      } catch {}
+      textarea.remove();
+
+      try {
+        selection?.removeAllRanges();
+        for (const range of savedRanges) selection?.addRange(range);
+        active?.focus?.({ preventScroll: true });
+      } catch {}
+      return copied;
+    };
+
+    const showManualCopyDialog = (text) => {
+      // prompt 的文本框在移动浏览器中可长按选择，作为最后一级无权限回退。
+      try {
+        w.prompt(t("web.clipboard.manualCopy"), text);
+      } catch {}
+    };
+
+    const writeText = async (value, options = {}) => {
+      const text = String(value ?? "");
+      let nativeError = null;
+      if (!options.skipNative && diagnostics.secureContext && nativeWriteText) {
+        try {
+          await nativeWriteText(text);
+          recordClipboardPath("async-clipboard", null);
+          return;
+        } catch (error) {
+          nativeError = error;
+        }
+      }
+      if (legacySelectionCopy(text)) {
+        recordClipboardPath("legacy-selection-copy", nativeError);
+        return;
+      }
+      showManualCopyDialog(text);
+      recordClipboardPath("manual-copy-dialog", nativeError);
+    };
+
+    const plainTextFromClipboardItems = async (items) => {
+      for (const item of Array.from(items || [])) {
+        if (!item || typeof item.getType !== "function") continue;
+        const types = Array.from(item.types || []);
+        if (!types.includes("text/plain")) continue;
+        try {
+          const blob = await item.getType("text/plain");
+          if (blob && typeof blob.text === "function") return await blob.text();
+        } catch {}
+      }
+      return null;
+    };
+
+    const writeItems = async (items) => {
+      let nativeError = null;
+      if (nativeWrite) {
+        try {
+          await nativeWrite(items);
+          recordClipboardPath("async-clipboard", null);
+          return;
+        } catch (error) {
+          nativeError = error;
+        }
+      }
+      const plainText = await plainTextFromClipboardItems(items);
+      if (plainText !== null) return writeText(plainText, { skipNative: true });
+      recordClipboardPath("async-clipboard-unsupported", nativeError);
+      throw nativeError || new Error("Clipboard items do not contain text/plain");
+    };
+
+    browserClipboardCapability = Object.freeze({ writeText });
+    w.browserClipboard = browserClipboardCapability;
+
+    const replacement = { writeText };
+    // 安全上下文保留读取和富文本写入能力；HTTP 下故意不暴露 write，让官方 helper 降级到纯文本 writeText。
+    if (diagnostics.secureContext) {
+      if (nativeWrite) replacement.write = writeItems;
+      if (nativeReadText) replacement.readText = (...args) => nativeReadText(...args);
+      if (nativeRead) replacement.read = (...args) => nativeRead(...args);
+    }
+
+    try {
+      Object.defineProperty(nav, "clipboard", {
+        configurable: true,
+        value: replacement,
+      });
+      diagnostics.installed = nav.clipboard === replacement;
+    } catch {
+      try {
+        Object.defineProperty(nativeClipboard, "writeText", {
+          configurable: true,
+          value: writeText,
+        });
+        if (diagnostics.secureContext && nativeWrite) {
+          Object.defineProperty(nativeClipboard, "write", {
+            configurable: true,
+            value: writeItems,
+          });
+        }
+        diagnostics.installed = nativeClipboard?.writeText === writeText;
+      } catch {}
+    }
+    w.__OpenCodexBrowserClipboardInstalled = diagnostics.installed;
+  }
+
   installLocaleOverride();
   installRandomUUIDPolyfill();
+  installBrowserClipboard();
 
   /**
    * Electron 的 <webview> 在浏览器里不存在。
@@ -2476,6 +2655,11 @@
     target.windowType = "electron";
     target.openExternal = (url) => openExternal(url);
     target.setWindowTitle = (title) => setWindowTitle(title);
+    // 兼容官方 preload 的常见剪贴板形态，所有写入均落在当前浏览器。
+    target.clipboard = browserClipboardCapability;
+    target.writeText = (value) => browserClipboardCapability.writeText(value);
+    target.copyText = target.writeText;
+    target.copyToClipboard = target.writeText;
     target.getAccount = () => invoke("account-info");
     target.addAuthStatusCallback = (callback) => {
       if (typeof callback !== "function") return () => {};
@@ -2753,6 +2937,8 @@
         return {
           ipcRenderer: w.electronBridge,
           shell: { openExternal },
+          // Renderer 中遗留的 Electron clipboard 调用同样写入当前浏览器。
+          clipboard: browserClipboardCapability,
           contextBridge: { exposeInMainWorld() {} },
         };
       }

--- a/web-shell/index.html
+++ b/web-shell/index.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN" class="electron-light" data-codex-window-type="browser">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content" />
     <meta http-equiv="Cache-Control" content="no-store" />
     <!-- PWA 元数据只提供可安装壳，不引入 Service Worker 或离线缓存。 -->
     <link rel="manifest" href="/manifest.webmanifest" crossorigin="use-credentials" />

--- a/web-shell/plugins/ios-fix/index.js
+++ b/web-shell/plugins/ios-fix/index.js
@@ -94,6 +94,9 @@
       let markedAppShell = null;
       let largestObservedLayoutHeight = 0;
       let lastDebugState = null;
+      let previousKeyboardVisible = false;
+      let wasAtBottomBeforeFocus = false;
+      let userHasScrolled = false;
       const settleTimers = new Set();
 
       const isEnabled = () => context.plugin.isEnabled();
@@ -148,9 +151,16 @@
         if (document.body) document.body.scrollTop = 0;
       };
 
+      const threadScrollIsAtBottom = () => {
+        const scroller = threadScrollElement();
+        if (!isElement(scroller)) return false;
+        // 官方 thread 使用 flex-col-reverse，底部位置的 scrollTop 接近 0。
+        return Math.abs(Number(scroller.scrollTop || 0)) <= 2;
+      };
+
       const settleThreadScroll = () => {
         const scroller = threadScrollElement();
-        if (!isElement(scroller) || !activeEditableElement()) return;
+        if (!isElement(scroller) || !activeEditableElement()) return false;
         // 官方 thread 使用 flex-col-reverse，scrollTop=0 才是贴底。
         try {
           scroller.scrollTo({ top: 0, behavior: "auto" });
@@ -160,6 +170,7 @@
           } catch {}
         }
         scroller.scrollTop = 0;
+        return true;
       };
 
       const elementDebug = (element) => {
@@ -280,9 +291,10 @@
             box-sizing: border-box !important;
             width: 100vw !important;
             max-width: 100vw !important;
-            height: var(--opencodex-ios-app-height) !important;
-            min-height: var(--opencodex-ios-app-height) !important;
-            max-height: var(--opencodex-ios-app-height) !important;
+            /* html 保留完整布局视口，不能用可视高度裁剪带 offsetTop 的应用壳。 */
+            height: 100% !important;
+            min-height: 100% !important;
+            max-height: none !important;
             overflow: hidden !important;
             overflow-x: hidden !important;
             overscroll-behavior: none !important;
@@ -293,27 +305,39 @@
           }
 
           html[data-opencodex-ios-fix="true"] body {
-            /* iOS 底部地址栏会压缩 visualViewport，这里固定到实际可视高度。 */
-            position: fixed !important;
-            top: var(--opencodex-ios-visual-viewport-offset-top, 0px) !important;
-            right: 0 !important;
-            bottom: auto !important;
-            left: 0 !important;
+            /* body/#root 只提供完整祖先空间，可视几何统一交给最外层 app shell。 */
+            position: static !important;
             box-sizing: border-box !important;
             width: 100% !important;
             max-width: 100vw !important;
-            height: var(--opencodex-ios-app-height) !important;
-            min-height: var(--opencodex-ios-app-height) !important;
-            max-height: var(--opencodex-ios-app-height) !important;
+            height: 100% !important;
+            min-height: 0 !important;
+            max-height: none !important;
             overflow: hidden !important;
             overflow-x: hidden !important;
             overscroll-behavior: none !important;
           }
 
-          html[data-opencodex-ios-fix="true"] #root,
-          html[data-opencodex-ios-fix="true"] [data-opencodex-ios-app-shell="true"] {
-            /* 官方根容器常带 100vh/100dvh，高度必须直接覆盖到 visualViewport。 */
+          html[data-opencodex-ios-fix="true"] #root {
             box-sizing: border-box !important;
+            position: relative !important;
+            width: 100% !important;
+            max-width: 100vw !important;
+            height: 100% !important;
+            min-height: 0 !important;
+            max-height: none !important;
+            overflow: hidden !important;
+            overflow-x: hidden !important;
+          }
+
+          html[data-opencodex-ios-fix="true"] [data-opencodex-ios-app-shell="true"] {
+            /* 只有 app shell 同时消费 visualViewport 的顶部偏移和可视高度。 */
+            box-sizing: border-box !important;
+            position: fixed !important;
+            top: var(--opencodex-ios-visual-viewport-offset-top, 0px) !important;
+            right: 0 !important;
+            bottom: auto !important;
+            left: 0 !important;
             width: 100% !important;
             max-width: 100vw !important;
             height: var(--opencodex-ios-app-height) !important;
@@ -354,6 +378,7 @@
             height: 100% !important;
             max-height: 100% !important;
             overflow-y: auto !important;
+            touch-action: pan-y;
             overscroll-behavior: contain !important;
             scroll-padding-bottom: 0px !important;
             -webkit-overflow-scrolling: touch;
@@ -392,6 +417,7 @@
         root.style.removeProperty("--opencodex-ios-keyboard-inset-bottom");
         clearAppShellMark();
         lastDebugState = null;
+        previousKeyboardVisible = false;
       };
 
       const viewportMetrics = () => {
@@ -451,6 +477,8 @@
         root.style.setProperty("--opencodex-ios-keyboard-inset-bottom", cssPixel(metrics.keyboardInset));
         syncAppShellMark(true);
 
+        const keyboardJustOpened = metrics.keyboardVisible && !previousKeyboardVisible;
+
         lastDebugState = {
           keyboardInset: roundedNumber(metrics.keyboardInset),
           keyboardOpening: metrics.keyboardOpening,
@@ -462,10 +490,14 @@
           visualHeight: roundedNumber(metrics.visualHeight),
         };
 
-        if (metrics.keyboardVisible || metrics.editable) {
+        if (metrics.editable) {
           resetDocumentScroll();
+        }
+        if (keyboardJustOpened && wasAtBottomBeforeFocus && !userHasScrolled) {
+          // 只在键盘首次打开且用户原本贴底时校准一次，流式 DOM 更新不得覆盖用户上滚意图。
           settleThreadScroll();
         }
+        previousKeyboardVisible = metrics.keyboardVisible;
       };
 
       const clearSettleTimers = () => {
@@ -497,13 +529,13 @@
       const observeAppTree = () => {
         if (mutationObserver || !document.body || typeof w.MutationObserver !== "function") return;
         mutationObserver = new w.MutationObserver(() => {
+          // app shell 稳定挂载后忽略流式消息的子树变化，避免每个 token 都触发布局测量。
+          if (isElement(markedAppShell) && markedAppShell !== rootElement() && markedAppShell.isConnected) return;
           if (mutationSettleTimer) w.clearTimeout(mutationSettleTimer);
-          // 官方 renderer 会分批挂载节点，稍后统一定位 app shell，减少重复测量。
-          mutationSettleTimer = w.setTimeout(scheduleViewportUpdate, 50);
+          // DOM 变化只重新定位 app shell，不能在流式输出期间改变任何滚动位置。
+          mutationSettleTimer = w.setTimeout(() => syncAppShellMark(isActive()), 50);
         });
         mutationObserver.observe(document.body, {
-          attributeFilter: ["class", "style"],
-          attributes: true,
           childList: true,
           subtree: true,
         });
@@ -511,6 +543,8 @@
 
       const handleFocusIn = () => {
         if (activeEditableElement()) {
+          wasAtBottomBeforeFocus = threadScrollIsAtBottom();
+          userHasScrolled = false;
           // 键盘动画开始前先进入 keyboard-visible 状态，避免 iOS 自动滚动留下旧布局空白。
           keyboardOpeningUntilMs = Date.now() + KEYBOARD_OPENING_GUARD_MS;
         }
@@ -520,6 +554,22 @@
       const handleFocusOut = () => {
         keyboardOpeningUntilMs = 0;
         scheduleViewportUpdate();
+      };
+
+      const handleThreadScrollIntent = (event) => {
+        if (!isActive() || !activeEditableElement()) return;
+        const scroller = threadScrollElement();
+        const target = event?.target;
+        if (!isElement(scroller) || !target || (target !== scroller && !scroller.contains(target))) return;
+        if (isElement(target) && target.closest(`${EDITABLE_SELECTOR},${COMPOSER_SELECTOR}`)) return;
+        // 手势一旦落在消息区，就停止本次聚焦周期的自动贴底。
+        userHasScrolled = true;
+      };
+
+      const handleThreadScroll = (event) => {
+        if (event?.isTrusted && event.target === threadScrollElement() && activeEditableElement()) {
+          userHasScrolled = true;
+        }
       };
 
       const disposePreference = context.events.on("plugin:enabled-changed", (payload) => {
@@ -534,6 +584,9 @@
       w.visualViewport?.addEventListener("scroll", scheduleViewportUpdate, { passive: true });
       document.addEventListener("focusin", handleFocusIn, true);
       document.addEventListener("focusout", handleFocusOut, true);
+      document.addEventListener("touchstart", handleThreadScrollIntent, { capture: true, passive: true });
+      document.addEventListener("wheel", handleThreadScrollIntent, { capture: true, passive: true });
+      document.addEventListener("scroll", handleThreadScroll, true);
 
       return () => {
         disposePreference();
@@ -547,6 +600,9 @@
         w.visualViewport?.removeEventListener("scroll", scheduleViewportUpdate, { passive: true });
         document.removeEventListener("focusin", handleFocusIn, true);
         document.removeEventListener("focusout", handleFocusOut, true);
+        document.removeEventListener("touchstart", handleThreadScrollIntent, { capture: true, passive: true });
+        document.removeEventListener("wheel", handleThreadScrollIntent, { capture: true, passive: true });
+        document.removeEventListener("scroll", handleThreadScroll, true);
         if (style.parentNode) style.parentNode.removeChild(style);
         if (w[DEBUG_GLOBAL] === debugSnapshot) delete w[DEBUG_GLOBAL];
         clearViewportState();

--- a/web-shell/plugins/mobile-keyboard-optimization/index.js
+++ b/web-shell/plugins/mobile-keyboard-optimization/index.js
@@ -68,18 +68,41 @@
       style.textContent = `
         @media (max-width: 820px), (pointer: coarse) {
           html[data-opencodex-mobile-keyboard-optimization="true"]:not([data-opencodex-ios-keyboard-optimization="true"]),
-          html[data-opencodex-mobile-keyboard-optimization="true"]:not([data-opencodex-ios-keyboard-optimization="true"]) body,
-          html[data-opencodex-mobile-keyboard-optimization="true"]:not([data-opencodex-ios-keyboard-optimization="true"]) #root {
-            height: var(--codex-visual-viewport-height, 100dvh) !important;
-            min-height: var(--codex-visual-viewport-height, 100dvh) !important;
-            max-height: var(--codex-visual-viewport-height, 100dvh) !important;
+          html[data-opencodex-mobile-keyboard-optimization="true"]:not([data-opencodex-ios-keyboard-optimization="true"]) body {
+            /* 祖先保持完整布局视口，避免 visualViewport.offsetTop 把底部裁出可滚动范围。 */
+            height: 100% !important;
+            min-height: 0 !important;
+            max-height: none !important;
             overflow: hidden;
+          }
+
+          html[data-opencodex-mobile-keyboard-optimization="true"]:not([data-opencodex-ios-keyboard-optimization="true"]) #root {
+            /* 现代移动浏览器只让应用根节点消费动态视口高度。 */
+            height: 100dvh !important;
+            min-height: 0 !important;
+            max-height: 100dvh !important;
+            overflow: hidden;
+          }
+
+          @supports not (height: 100dvh) {
+            html[data-opencodex-mobile-keyboard-optimization="true"]:not([data-opencodex-ios-keyboard-optimization="true"]) #root {
+              height: var(--codex-visual-viewport-height, 100vh) !important;
+              max-height: var(--codex-visual-viewport-height, 100vh) !important;
+            }
           }
 
           html[data-opencodex-mobile-keyboard-optimization="true"] body {
             width: 100%;
             touch-action: pan-x pan-y;
             overscroll-behavior: none;
+          }
+
+          html[data-opencodex-mobile-keyboard-optimization="true"] .thread-scroll-container {
+            min-height: 0 !important;
+            overflow-y: auto !important;
+            touch-action: pan-y;
+            overscroll-behavior: contain;
+            -webkit-overflow-scrolling: touch;
           }
 
           html[data-opencodex-mobile-keyboard-optimization="true"] input,
@@ -183,12 +206,6 @@
         w.setTimeout(run, 240);
       };
 
-      const preventZoomGesture = (event) => {
-        if (!isEnabled() || !isMobile()) return;
-        if (event.touches && event.touches.length < 2) return;
-        event.preventDefault();
-      };
-
       const rememberManualFocusIntent = (event) => {
         const target = event && event.target;
         if (!target || typeof target.closest !== "function") return;
@@ -237,9 +254,6 @@
       w.visualViewport?.addEventListener("scroll", scheduleViewportUpdate, { passive: true });
       document.addEventListener("focusin", scheduleViewportUpdate, true);
       document.addEventListener("input", scheduleViewportUpdate, true);
-      document.addEventListener("touchmove", preventZoomGesture, { passive: false });
-      document.addEventListener("gesturestart", preventZoomGesture, { passive: false });
-      document.addEventListener("gesturechange", preventZoomGesture, { passive: false });
       document.addEventListener("pointerdown", rememberManualFocusIntent, true);
       document.addEventListener("touchstart", rememberManualFocusIntent, true);
 
@@ -252,9 +266,6 @@
         w.visualViewport?.removeEventListener("scroll", scheduleViewportUpdate, { passive: true });
         document.removeEventListener("focusin", scheduleViewportUpdate, true);
         document.removeEventListener("input", scheduleViewportUpdate, true);
-        document.removeEventListener("touchmove", preventZoomGesture, { passive: false });
-        document.removeEventListener("gesturestart", preventZoomGesture, { passive: false });
-        document.removeEventListener("gesturechange", preventZoomGesture, { passive: false });
         document.removeEventListener("pointerdown", rememberManualFocusIntent, true);
         document.removeEventListener("touchstart", rememberManualFocusIntent, true);
         if (style.parentNode) style.parentNode.removeChild(style);


### PR DESCRIPTION
## What changed

- keep the mobile layout rooted in the full viewport while applying dynamic viewport height only to the app shell
- stop streaming DOM mutations and repeated viewport events from forcing the thread back to the bottom after the user scrolls
- restore browser zoom gestures and make the thread pane explicitly touch-scrollable
- add a browser-local clipboard fallback chain for insecure LAN HTTP: Async Clipboard, legacy selection copy, then a selectable manual-copy dialog
- bump the patch version to 2.0.4 and use the modern electron-builder Windows code-signing toolset

## Why

The mobile shell constrained `html`, `body`, and `#root` to the visual viewport height without consistently accounting for its offset. On iOS, viewport and mutation observers also reapplied `scrollTop = 0` while output streamed, overriding user scroll intent. In LAN HTTP pages, `navigator.clipboard` is unavailable or rejected because the page is not a secure context.

## User impact

Android and iOS browsers can reach the bottom composer and scroll message history while the soft keyboard is open. Copy actions now remain in the current browser and degrade to a manual selectable dialog when browser permissions prevent automatic clipboard writes.

## Validation

- `git diff --check`
- `node --check` for the bridge and both mobile plugins
- locale and package JSON parsing
- `node scripts/sync-app-version.cjs --check`
- `pnpm run build:gateway`
- `pnpm run launcher:dist:win` (generated the 2.0.4 NSIS installer and Windows ZIP; executable version resources verified)

Per the request, the installed application was not launched and the real project test suite was not run.

## Log analysis note

The sampled gateway log points to slow official App Server discovery rather than slow LAN transport: `mcpServerStatus/list` averaged about 32.4 seconds and reached 46.4 seconds, while normal thread and filesystem RPCs remained fast and no Gateway request timeouts were found. This hotfix intentionally does not cache or suppress dynamic MCP/app/plugin status calls.
