### PR TITLE
fix(polyfill): resolve browser window focus

### DIFF
--- a/gateway/test/static-assets.test.cjs
+++ b/gateway/test/static-assets.test.cjs
@@ -3,6 +3,7 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
+const vm = require("node:vm");
 const { PATCHED_OFFICIAL_PREFIX } = require("../runtime/core/config.cjs");
 const { pluginMessagesForLocale } = require("../runtime/core/plugin-assets.cjs");
 const { createStaticAssetService } = require("../runtime/http/static-assets.cjs");
@@ -61,6 +62,64 @@ const TOKEN_USAGE_INLINE_PLUGIN = path.resolve(
   "token-usage-inline",
   "index.js"
 );
+const MESSAGE_FOR_VIEW_CHANNEL = "codex_desktop:message-for-view";
+const WINDOW_FOCUS_CHANGED_MESSAGE = "electron-window-focus-changed";
+
+function sourceFunctionDeclaration(source, name) {
+  const start = source.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `missing function ${name}`);
+  const bodyStart = source.indexOf("{", start);
+  let depth = 0;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] !== "}") continue;
+    depth -= 1;
+    if (depth === 0) return source.slice(start, index + 1);
+  }
+  assert.fail(`unterminated function ${name}`);
+}
+
+function createBrowserFocusHarness(bridge) {
+  const windowListeners = new Map();
+  const documentListeners = new Map();
+  const emitted = [];
+  let hasFocus = true;
+  const context = {
+    document: {
+      visibilityState: "visible",
+      hasFocus: () => hasFocus,
+      addEventListener: (type, handler) => documentListeners.set(type, handler),
+    },
+    emitWindowMessage: (channel, payload) => emitted.push({ channel, payload }),
+    w: { addEventListener: (type, handler) => windowListeners.set(type, handler) },
+  };
+  const functionNames = [
+    "browserWindowIsFocused",
+    "emitBrowserWindowFocusChanged",
+    "browserRendererMessagePayload",
+    "installBrowserWindowFocusBridge",
+    "effectiveGatewayMessageChannel",
+  ];
+  const declarations = functionNames.map((name) => sourceFunctionDeclaration(bridge, name)).join("\n");
+  // 执行生产函数本身，避免只验证源码字符串存在而漏掉 focus payload 行为回归。
+  const focusBridge = vm.runInNewContext(
+    `const MESSAGE_FOR_VIEW_CHANNEL = ${JSON.stringify(MESSAGE_FOR_VIEW_CHANNEL)};
+     const WINDOW_FOCUS_CHANGED_MESSAGE = ${JSON.stringify(WINDOW_FOCUS_CHANGED_MESSAGE)};
+     ${declarations}
+     ({ ${functionNames.join(", ")} })`,
+    context
+  );
+  return {
+    context,
+    documentListeners,
+    emitted,
+    focusBridge,
+    setFocus: (value) => {
+      hasFocus = value;
+    },
+    windowListeners,
+  };
+}
 
 function makeTempDir(t) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "opencodex-static-assets-test-"));
@@ -223,6 +282,51 @@ test("bridge reconnects active app-host ports after websocket hello", () => {
 
   assert.match(bridge, /state\.pending\.unshift\(appHostWsPayload\(state, \{ type: "app-host-connect" \}\)\)/);
   assert.match(bridge, /for \(const state of appHostPortRelays\.values\(\)\) state\.connected = false/);
+});
+
+test("bridge resolves window focus from the browser instead of the hidden Electron proxy", () => {
+  const bridge = fs.readFileSync(BRIDGE_POLYFILL, "utf-8");
+  const { context, documentListeners, emitted, focusBridge, setFocus, windowListeners } =
+    createBrowserFocusHarness(bridge);
+
+  const effectiveChannel = focusBridge.effectiveGatewayMessageChannel(MESSAGE_FOR_VIEW_CHANNEL, {
+    type: WINDOW_FOCUS_CHANGED_MESSAGE,
+    isFocused: false,
+  });
+  assert.equal(effectiveChannel, WINDOW_FOCUS_CHANGED_MESSAGE);
+
+  const electronPayload = { isFocused: false, source: "hidden-electron-window" };
+  const browserPayload = focusBridge.browserRendererMessagePayload(effectiveChannel, electronPayload);
+  assert.equal(browserPayload.isFocused, true);
+  assert.equal(browserPayload.source, "hidden-electron-window");
+  assert.notEqual(browserPayload, electronPayload);
+
+  const unrelatedPayload = { value: 1 };
+  assert.equal(focusBridge.browserRendererMessagePayload("unrelated-message", unrelatedPayload), unrelatedPayload);
+
+  setFocus(false);
+  assert.equal(focusBridge.browserRendererMessagePayload(WINDOW_FOCUS_CHANGED_MESSAGE, null).isFocused, false);
+  setFocus(true);
+  context.document.visibilityState = "hidden";
+  assert.equal(focusBridge.browserRendererMessagePayload(WINDOW_FOCUS_CHANGED_MESSAGE, {}).isFocused, false);
+
+  context.document.visibilityState = "visible";
+  focusBridge.installBrowserWindowFocusBridge();
+  assert.deepEqual([...windowListeners.keys()], ["focus", "blur"]);
+  assert.deepEqual([...documentListeners.keys()], ["visibilitychange"]);
+  windowListeners.get("focus")();
+  assert.equal(emitted.at(-1).channel, WINDOW_FOCUS_CHANGED_MESSAGE);
+  assert.equal(emitted.at(-1).payload.isFocused, true);
+  setFocus(false);
+  windowListeners.get("blur")();
+  assert.equal(emitted.at(-1).payload.isFocused, false);
+  documentListeners.get("visibilitychange")();
+  assert.equal(emitted.at(-1).payload.isFocused, false);
+
+  // 保留一条 wiring 断言，确保 WebSocket 入站数据实际经过已执行验证的 normalizer。
+  assert.match(bridge, /browserRendererMessagePayload\(effectiveChannel, messagePayload\)/);
+  assert.match(bridge, /dispatch\(effectiveChannel, rendererMessagePayload\)/);
+  assert.match(bridge, /emitWindowMessage\(effectiveChannel, rendererMessagePayload\)/);
 });
 
 test("patched official renderer CSP allows the injected PWA manifest", (t) => {
@@ -498,20 +602,7 @@ test("smart scheduling summary follows root-path task context while Auto remains
 
 test("inline token usage shares the assistant action group visibility", () => {
   const source = fs.readFileSync(TOKEN_USAGE_INLINE_PLUGIN, "utf-8");
-
-  function functionDeclaration(name) {
-    const start = source.indexOf(`function ${name}(`);
-    assert.notEqual(start, -1, `missing ${name}`);
-    const bodyStart = source.indexOf("{", start);
-    let depth = 0;
-    for (let index = bodyStart; index < source.length; index += 1) {
-      if (source[index] === "{") depth += 1;
-      if (source[index] !== "}") continue;
-      depth -= 1;
-      if (depth === 0) return source.slice(start, index + 1);
-    }
-    throw new Error(`unterminated ${name}`);
-  }
+  const functionDeclaration = (name) => sourceFunctionDeclaration(source, name);
 
   const { insertUsageBadge } = new Function(
     `${functionDeclaration("directChildForInsert")}

--- a/web-shell/codex-bridge-polyfill.js
+++ b/web-shell/codex-bridge-polyfill.js
@@ -44,6 +44,7 @@
     "Log out of Codex",
   ];
   const MESSAGE_FOR_VIEW_CHANNEL = "codex_desktop:message-for-view";
+  const WINDOW_FOCUS_CHANGED_MESSAGE = "electron-window-focus-changed";
 
   function installLocaleOverride() {
     try {
@@ -1141,6 +1142,32 @@
     } catch (error) {
       console.warn("[codex-web] failed to emit window message", channel, error);
     }
+  }
+
+  /** 浏览器页面才是真实交互窗口，不能沿用隐藏 Electron 代理窗口的 focus 状态。 */
+  function browserWindowIsFocused() {
+    return document.visibilityState !== "hidden" && document.hasFocus();
+  }
+
+  /** 按官方 preload 的 MessageEvent 契约同步浏览器窗口 focus 状态。 */
+  function emitBrowserWindowFocusChanged() {
+    emitWindowMessage(WINDOW_FOCUS_CHANGED_MESSAGE, { isFocused: browserWindowIsFocused() });
+  }
+
+  /** hidden Electron 代理窗口的 focus 状态不代表浏览器，入站时统一替换为页面真实状态。 */
+  function browserRendererMessagePayload(channel, payload) {
+    if (channel !== WINDOW_FOCUS_CHANGED_MESSAGE) return payload;
+    return {
+      ...(payload && typeof payload === "object" ? payload : {}),
+      isFocused: browserWindowIsFocused(),
+    };
+  }
+
+  /** 页面 focus 或可见性变化时持续更新 renderer 状态，避免后续快捷键和 onboarding 使用陈旧值。 */
+  function installBrowserWindowFocusBridge() {
+    w.addEventListener("focus", emitBrowserWindowFocusChanged);
+    w.addEventListener("blur", emitBrowserWindowFocusChanged);
+    document.addEventListener("visibilitychange", emitBrowserWindowFocusChanged);
   }
 
   /** 官方 main 发给 renderer 的消息通常用 message-for-view 包一层，真实类型在 payload.type。 */
@@ -2793,6 +2820,7 @@
   w.codexBridge = createAdaptiveBridgeProxy(w.codexBridge, "codexBridge");
   w.electronAPI = createAdaptiveBridgeProxy(w.electronAPI, "electronAPI");
   w.electronBridge = createAdaptiveBridgeProxy(w.electronBridge, "electronBridge");
+  installBrowserWindowFocusBridge();
   installAppHostMessagePortBridge();
   installAppFsImageRewrite();
 
@@ -2972,10 +3000,11 @@
             surfaceFetchIpcError("fetch-stream-error", messagePayload);
           }
           handleTokenUsageGatewayPayload(messagePayload);
+          const rendererMessagePayload = browserRendererMessagePayload(effectiveChannel, messagePayload);
           if (shouldDispatchGatewayMessage(msg.channel, effectiveChannel)) {
-            dispatch(effectiveChannel, messagePayload);
+            dispatch(effectiveChannel, rendererMessagePayload);
           }
-          emitWindowMessage(effectiveChannel, messagePayload);
+          emitWindowMessage(effectiveChannel, rendererMessagePayload);
           if (WS_DEBUG_ENABLED) {
             maybeLogLargeOrSlowWsInbound({
               handledBy: "gateway-channel",


### PR DESCRIPTION
## Summary

- resolve official renderer focus from the browser window instead of the hidden Electron proxy
- normalize inbound `electron-window-focus-changed` payloads after `message-for-view` unwrapping
- keep renderer focus synchronized on browser `focus`, `blur`, and `visibilitychange`
- add executable behavior coverage for focus normalization and event delivery

## Bug

### Environment

- OpenCodex running as a Linux systemd service with the browser gateway exposed on port 3737
- official renderer hosted in a real Chromium browser while Electron runs as a hidden proxy
- reproducible when the hidden Electron `BrowserWindow` is not considered focused even though the browser page is active

The failure condition is the mismatch between Electron-window focus and browser-page focus. It is not specific to ARM, and it is not caused by Codex Desktop being uninitialized. ARM64, x86_64, WSL, or other Linux environments may behave differently depending on how the hidden Electron window, display server, and browser focus are initialized.

### Reproduction

1. Start OpenCodex through systemd in a headless or virtual-display environment.
2. Open the browser gateway on port 3737 and authenticate.
3. Focus the browser page while the hidden Electron proxy window remains unfocused.
4. Observe that the official renderer remains on the loading splash.

### Actual behavior

The service and browser gateway are reachable, but the official renderer never leaves the onboarding logo/loading splash, so no application content is accessible.

### Expected behavior

Once the browser page is visible and focused, the renderer should complete the splash lifecycle and display the onboarding or workspace content.

### Impact

This is a UI-blocking failure for affected browser-hosted deployments. The gateway and static assets can remain healthy, which makes the failure appear as an indefinite frontend load rather than a service error.

## Root cause

The browser-hosted official renderer still queried focus through the hidden Electron `BrowserWindow`. In headless/systemd environments that proxy can report `false` or `null` even while the browser page is focused. The onboarding logo animation then never receives a usable focused state and remains on the loading splash.

The fix preserves the official IPC lifecycle but replaces the hidden-window focus value at the Electron/Web boundary with `document.hasFocus()` plus `document.visibilityState`.

## Verification

- `pnpm test`: 170 passed
- `node --test gateway/test/static-assets.test.cjs`: 22 passed
- real Chromium against the systemd service on port 3737: authenticated renderer automatically left the splash and displayed onboarding content
- browser verification reported no HTTP 4xx/5xx responses
- Standards review: 0 findings
- Spec review: 0 findings
