### PR TITLE
fix(polyfill): suppress mobile-subscription billing 400 toasts

### DIFF
--- a/web-shell/codex-bridge-polyfill.js
+++ b/web-shell/codex-bridge-polyfill.js
@@ -1248,7 +1248,13 @@
 
   /** 只兜底展示 fetch 形态的 IPC 兼容错误，invoke 错误交给官方前端调用栈自然处理。 */
   function shouldSurfaceFetchIpcError(status, message) {
-    if (status === 400) return true;
+    if (status === 400) {
+      // 移动订阅（App Store / Google Play）的账单/支付方式提示对使用无影响，静默忽略，避免误弹故障弹窗
+      if (/payment methods for mobile subscriptions|mobile subscriptions must be managed/i.test(message || "")) {
+        return false;
+      }
+      return true;
+    }
     return /unsupported codex ipc channel|method not found|no electron ipc handler|invalid ipc channel/i.test(
       message || ""
     );


### PR DESCRIPTION
## Summary / 摘要

Suppress the spurious danger toast shown on every new session when the account's ChatGPT subscription is billed through a mobile platform (Apple App Store / Google Play). The runtime's billing check returns HTTP 400 with "Payment methods for mobile subscriptions must be managed in the mobile platform." — `shouldSurfaceFetchIpcError` treated any 400 as a fatal IPC error, but this one is harmless and the official app silently ignores it.

修复一个问题：当 ChatGPT 订阅走移动平台（App Store / Google Play）扣费时，新建会话时的账单检查会返回 HTTP 400（"Payment methods for mobile subscriptions must be managed in the mobile platform."）。`shouldSurfaceFetchIpcError` 把一切 400 都当作致命 IPC 错误来弹窗，但这类账单提示对使用毫无影响，官方 App 也是静默忽略的——结果就是每次新建会话都会误弹一次故障提示。

## What changed / 改动内容

- In `web-shell/codex-bridge-polyfill.js`, `shouldSurfaceFetchIpcError` now ignores 400 responses whose message matches the mobile-subscription billing pattern; all other 400s and IPC channel errors still surface unchanged.
- 在 `web-shell/codex-bridge-polyfill.js` 的 `shouldSurfaceFetchIpcError` 中，忽略消息匹配「移动订阅账单」模式的 400 响应；其余 400 与 IPC 通道错误仍照常提示，行为不变。

## Verification / 验证

- New sessions no longer show the toast; non-billing 400 handling is untouched.
- 新建会话不再误弹提示；非账单类 400 的处理逻辑未改动。
