### PR TITLE
fix(gateway): serve official app-menu icons from apps path

### DIFF
--- a/gateway/runtime/http/static-assets.cjs
+++ b/gateway/runtime/http/static-assets.cjs
@@ -80,6 +80,11 @@ const OFFICIAL_LOADING_SHIMMER_POWER_GUARD = [
   "</style>",
 ].join("");
 const WEB_SHELL_ASSETS_DIR = path.join(WEB_SHELL_DIR, "assets");
+/**
+ * 官方 main 运行时把“打开方式”菜单图标写成相对路径 `apps/<name>.png`。
+ * 浏览器按当前页面 URL 解析它，因此站点根得到 /apps/，深链路由得到 /<route>/apps/。
+ */
+const OFFICIAL_APP_ICON_FILE = /^[A-Za-z0-9][A-Za-z0-9._-]*\.(?:png|svg|webp|avif|ico|jpe?g|gif)$/i;
 const OPENCODEX_MODIFICATION_RUNTIME_FILE = path.join(
   __dirname,
   "..",
@@ -1060,6 +1065,16 @@ function createStaticAssetService({
     return fileName ? `/official/assets/${fileName}` : null;
   }
 
+  /**
+   * 把浏览器解析出的 apps 图标请求映射回官方 webview/apps/ 目录。
+   * 只接受单个图片文件名，避免 /apps/ 变成整个 webview 目录的第二个读入口；
+   * `..` 与 `%2e%2e` 都进不了这条正则，越界路径还会被 locateOfficialAsset 再校验一次。
+   */
+  function locateOfficialAppIcon(relPath) {
+    if (!OFFICIAL_APP_ICON_FILE.test(relPath)) return null;
+    return locateOfficialAsset(`apps/${relPath}`);
+  }
+
   function officialAssetFileNames(officialBundle = getOfficialBundle()) {
     if (!officialBundle || !officialBundle.webviewDir) return [];
     if (officialAssetFileNamesCache?.webviewDir === officialBundle.webviewDir) {
@@ -1519,6 +1534,9 @@ ${pluginGatewayStateBootstrapScript()}
       const rel = reqPath.slice("/official/".length);
       return locateOfficialAsset(rel);
     }
+    // 官方图标相对路径会带上当前路由前缀，所以按最后一段 apps/<file> 匹配。
+    const appIconMatch = /\/apps\/([^/]+)$/.exec(reqPath);
+    if (appIconMatch) return locateOfficialAppIcon(appIconMatch[1]);
     return null;
   }
 
@@ -1548,6 +1566,8 @@ ${pluginGatewayStateBootstrapScript()}
     if (reqPath.startsWith("/official/assets/")) return "public, max-age=31536000, immutable";
     if (reqPath.startsWith(WEB_SHELL_ASSETS_PREFIX)) return "public, max-age=86400";
     if (reqPath.startsWith("/official/")) return "public, max-age=3600";
+    // 图标名不带 content hash，只做短期缓存，升级换图标后最多一小时内自行刷新。
+    if (/\/apps\/[^/]+\.(?:png|svg|webp|avif|ico|jpe?g|gif)$/i.test(reqPath)) return "public, max-age=3600";
     if (WEB_SHELL_STATIC_FILES.has(reqPath) || reqPath.startsWith(OPENCODEX_PLUGIN_URL_PREFIX)) {
       // 文件名不带 hash，必须每次验证；内容未变时允许 304，避免远端刷新重复传输整套 Web 扩展脚本。
       return "private, no-cache, must-revalidate";

--- a/gateway/test/static-assets.test.cjs
+++ b/gateway/test/static-assets.test.cjs
@@ -1778,3 +1778,41 @@ test("patched asset cache honors explicit encoding exclusions and evicts old var
   assert.equal(service.assetCacheDiagnostics().entries, 1);
   assert.equal(service.assetCacheDiagnostics().bytes <= service.assetCacheDiagnostics().maxBytes, true);
 });
+
+test("official app-menu icons resolve from the site-root /apps/ prefix", (t) => {
+  const webviewDir = makeOfficialWebviewDir(t);
+  const iconPath = path.join(webviewDir, "apps");
+  fs.mkdirSync(iconPath, { recursive: true });
+  fs.writeFileSync(path.join(iconPath, "file-explorer.png"), Buffer.from("89504e470d0a1a0a", "hex"));
+  const service = createService(webviewDir);
+
+  // 官方 main 运行时给出相对路径 apps/file-explorer.png，浏览器按站点根解析成 /apps/。
+  assert.equal(
+    service.staticFile("/apps/file-explorer.png"),
+    path.join(iconPath, "file-explorer.png")
+  );
+  const res = makeResponseRecorder();
+  service.serveFile(
+    { headers: { host: "localhost:3737" } },
+    res,
+    service.staticFile("/apps/file-explorer.png"),
+    200,
+    "/apps/file-explorer.png"
+  );
+  assert.equal(res.status, 200);
+  assert.equal(res.headers["content-type"], "image/png");
+  assert.equal(res.headers["cache-control"], "public, max-age=3600");
+
+  // 官方相对路径在深链路由下会带上前缀，同样要命中的是官方图标目录。
+  assert.equal(
+    service.staticFile("/settings/thread/apps/file-explorer.png"),
+    path.join(iconPath, "file-explorer.png")
+  );
+
+  // 图标映射只能读单个图片文件，不能穿透成整个 webview 目录的第二个读入口。
+  assert.equal(service.staticFile("/apps/../index.html"), null);
+  assert.equal(service.staticFile("/apps/%2e%2e/index.html"), null);
+  assert.equal(service.staticFile("/apps/sub/icon.png"), null);
+  assert.equal(service.staticFile("/apps/missing.png"), null);
+  assert.equal(service.staticFile("/apps/icon.txt"), null);
+});


### PR DESCRIPTION
## 问题
 
远程访问 Web Gateway 时，官方“打开方式”菜单里的文件管理器图标加载失败，浏览器出现：
 
```text
GET https://<host>/apps/file-explorer.png 404 (Not Found)
```
 
同一页面里 OpenCodex 自己的 `/assets/pwa-icon-192.png` 正常返回，只有 `apps/*.png` 全部 404，菜单项显示为缺图。
 
## 根因
 
官方 main 运行时（官方 bundle 的 `.vite/build/main-*.js`）把菜单图标声明成相对路径：
 
```js
{ id: "systemDefault", label: "File Manager", icon: `apps/file-explorer.png`, ... }
```
 
图标实体在官方 bundle 的 `webview/apps/`（与 `webview/assets/` 同级），但浏览器按当前页面 URL 解析这个相对路径：
 
- 站点根页面解析成 `/apps/file-explorer.png`
- 深链路由（例如 `/settings/...`）解析成 `/settings/.../apps/file-explorer.png`
 
静态资源层的 `staticFile()` 只映射 `/official/`、`/official-patched-v*/`、`/assets/`、插件目录和一组写死的 web-shell 文件，没有一条能命中 `apps/`，所以这些请求最终落到兜底 404。
 
验证根因的方式：同一份文件走 `/official/apps/file-explorer.png` 能返回 200，说明文件在缓存里，缺的只是 URL 前缀映射。
 
## 修改内容
 
- 在 `staticFile()` 增加一条按末尾 `apps/<file>` 匹配的映射，因此站点根和带路由前缀两种解析结果都命中官方 `webview/apps/`。
- 新增 `locateOfficialAppIcon()`：只接受单个图片文件名（`png/svg/webp/avif/ico/jpg/jpeg/gif`），再复用 `locateOfficialAsset()` 的 webview 根目录校验。`..`、`%2e%2e` 与子目录都会被拒，避免 `apps/` 变成整个官方 webview 目录的第二个读入口。
- 缓存策略给 `public, max-age=3600`：图标文件名不带 Vite content hash，不能进 immutable 长缓存，否则升级换图后长期停留在旧图。
 
## 验证
 
用真实官方 bundle 目录实例化静态资源服务：
 
```text
/apps/file-explorer.png              => 200 image/png public, max-age=3600
/settings/local/apps/file-explorer.png => 200 image/png public, max-age=3600
/apps/../index.html                  => 404
/apps/%2e%2e/index.html              => 404
/index.html                          => 404
```
 
测试与门禁：
 
- 新增回归用例覆盖站点根命中、深链前缀命中、穿越与子目录被拒、缺失文件 404、`content-type` 与 `cache-control`。
- `node --test gateway/test/static-assets.test.cjs`：49 passed / 0 failed。
- `pnpm run build:gateway`（含 typecheck、skeleton 构建与 modification 边界检查）通过。
- 全量 `node --test gateway/test/*.test.cjs launcher/test/log-writer.test.cjs`：406 tests / 403 passed / 3 failed。未打本补丁的基线同样是 3 failed，且为同一批用例（`official-desktop-compat` 里探测 macOS/Windows 默认安装路径的用例）。这台 Linux 机器上真实存在 `/usr/lib/chatgpt`，被这些用例探测到，与本改动无关。
 
## 影响面
 
只增加一条静态资源映射与对应的缓存分支，不改动官方产物、不改 HTML 注入、不触碰鉴权顺序（`apps/` 仍位于认证门之后，只服务于已认证页面渲染出的菜单）。
